### PR TITLE
Only use the controller client for breakpoint actions.

### DIFF
--- a/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Debuglet.cs
+++ b/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Debuglet.cs
@@ -43,7 +43,7 @@ namespace Google.Cloud.Diagnostics.Debug
         private Debuggee _debuggee;
         private Process _process;
 
-        private Debuglet(DebugletOptions options, Debugger2Client debugClient = null, Controller2Client controlClient = null)
+        private Debuglet(DebugletOptions options, Controller2Client controlClient = null)
         {
             _options = GaxPreconditions.CheckNotNull(options, nameof(options));
             _controlClient = controlClient ?? Controller2Client.Create();


### PR DESCRIPTION
I misread some docs, we should not use the debugger client.

Also removed left over debugging and TODO. The timer is not sequential so the current option is probably the safest.