### PR TITLE
Retry on more failures on unix named pipe connections.

### DIFF
--- a/google_cloud_debugger_lib/named_pipe_client_unix.cc
+++ b/google_cloud_debugger_lib/named_pipe_client_unix.cc
@@ -60,7 +60,8 @@ HRESULT NamedPipeClient::WaitForConnection() {
       break;
     }
 
-    if (conn == -1 && errno != ENOENT) {
+    // If the connection is refused or times out we should retry.
+    if (conn == -1 && !(errno == ENOENT || errno == ECONNREFUSED || errno == ETIMEDOUT)) {
       cerr << "connect error: " << strerror(errno) << std::endl;
       return E_FAIL;
     }


### PR DESCRIPTION
These are retry-able connections that should be retired in our timeout window.