### PR TITLE
Add a test to check that the latency requirements (10ms) are met when a breakpoint is being evaluated.

### DIFF
--- a/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTestBase.cs
+++ b/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTestBase.cs
@@ -88,12 +88,11 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
         }
 
         /// <summary>
-        /// Gets the average latency for requests to a give url.
+        /// Gets the average latency for requests to the <see cref="AppUrlEcho"/> url.
         /// </summary>
         /// <param name="numRequests">The number of requests to sample.</param>
-        /// <param name="url">Optional, the url to hit.  Defaults to <see cref="AppUrlEcho"/></param>
-        /// <returns>The average latency of requests to the given url.</returns>
-        public async Task<double> GetAverageLatencyAsync(int numRequests, string url = null)
+        /// <returns>The average latency of requests to the url.</returns>
+        public async Task<double> GetAverageLatencyAsync(int numRequests)
         {
             using (HttpClient client = new HttpClient())
             {
@@ -101,7 +100,7 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
                 for (int i = 0; i < numRequests; i++)
                 {
                     Stopwatch watch = Stopwatch.StartNew();
-                    HttpResponseMessage result = await client.GetAsync($"{url ?? AppUrlEcho}/{i}");
+                    await client.GetAsync($"{AppUrlEcho}/{i}");
                     totalTime += watch.Elapsed;
                 }
                 return totalTime.TotalMilliseconds / numRequests;

--- a/Google.Cloud.Diagnostics.Debug.PerformanceTests/RequestLatencyTests.cs
+++ b/Google.Cloud.Diagnostics.Debug.PerformanceTests/RequestLatencyTests.cs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 using Google.Cloud.Diagnostics.Debug.IntegrationTests;
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -57,7 +61,7 @@ namespace Google.Cloud.Diagnostics.Debug.PerformanceTests
                 debugAvgLatency = await GetAverageLatencyAsync(NumberOfRequest);
             }
 
-            Assert.True(debugAvgLatency <= noDebugAvgLatency + AddedLatencyWhenDebuggingMs);
+            AssertAcceptableLatency(noDebugAvgLatency, debugAvgLatency);
         }
 
         /// <summary>
@@ -90,7 +94,67 @@ namespace Google.Cloud.Diagnostics.Debug.PerformanceTests
                 Assert.False(newBp.IsFinalState);
             }
 
-            Assert.True(debugAvgLatency <= noDebugAvgLatency + AddedLatencyWhenDebuggingMs);
+            AssertAcceptableLatency(noDebugAvgLatency, debugAvgLatency);
+        }
+
+
+        /// <summary>
+        /// This test ensures the debugger does not add more than 10ms of
+        /// latency to a request when the debugger is attached and
+        /// breakpoint is hit.
+        /// 
+        /// This is tested by taking the average latency of request to an
+        /// application with no debugger attached and then the average latency
+        /// of requests to the same application with a debugger attached.
+        /// </summary>
+        [Fact]
+        public async Task DebuggerAttached_BreakpointHit()
+        {
+            double noDebugAvgLatency;
+            using (StartTestApp(debugEnabled: false))
+            {
+                noDebugAvgLatency = await GetAverageLatencyAsync(NumberOfRequest);
+            }
+
+            double debugAvgLatency;
+            using (StartTestApp(debugEnabled: true))
+            {
+                var debuggee = Polling.GetDebuggee(Module, Version);
+
+                using (HttpClient client = new HttpClient())
+                {
+                    TimeSpan totalTime = TimeSpan.Zero;
+                    for (int i = 0; i < NumberOfRequest; i++)
+                    {
+                        // Set a breakpoint and wait to ensure the debuggee picks it up.
+                        var breakpoint = SetBreakpoint(debuggee.Id, "MainController.cs", 31);
+                        Thread.Sleep(TimeSpan.FromSeconds(.5));
+
+                        Stopwatch watch = Stopwatch.StartNew();
+                        await client.GetAsync($"{AppUrlEcho}/{i}");
+                        totalTime += watch.Elapsed;
+                       
+                        var newBp = Polling.GetBreakpoint(debuggee.Id, breakpoint.Id);
+                        Assert.True(newBp.IsFinalState);
+                    }
+                    debugAvgLatency = totalTime.TotalMilliseconds / NumberOfRequest;
+                }                
+            }
+            AssertAcceptableLatency(noDebugAvgLatency, debugAvgLatency);
+        }
+
+        /// <summary>
+        /// Assert that the latency of requests to an app with a debugger and without are within
+        /// the acceptable range (10ms).
+        /// </summary>
+        /// <param name="noDebugAvgLatency">The average latency for requests to an app with no debugger attached.</param>
+        /// <param name="debugAvgLatency">The average latency for requests to an app with a debugger attached.</param>
+        private void AssertAcceptableLatency(double noDebugAvgLatency, double debugAvgLatency)
+        {
+            Assert.True(debugAvgLatency <= noDebugAvgLatency + AddedLatencyWhenDebuggingMs,
+               $"Avg latency w/o a debugger attached: {noDebugAvgLatency}\n" +
+               $"Avg latency w/ a debugger attached: {debugAvgLatency}\n" +
+               $"This is {debugAvgLatency - noDebugAvgLatency - AddedLatencyWhenDebuggingMs} more than expectable.");
         }
     }
 }


### PR DESCRIPTION
I ran this a few times and it looks like the average is about 5ms more with the debugger (and breakpoint hit) then without a debugger (Yay!).