### PR TITLE
Copy over the Dockerfile when publishing the test app.

### DIFF
--- a/Google.Cloud.Diagnostics.Debug.TestApp/Dockerfile
+++ b/Google.Cloud.Diagnostics.Debug.TestApp/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/csharp-debugger-eap/aspnetcore:1.1.4-2017-11-08_10_44
+FROM gcr.io/csharp-debugger-eap/aspnetcore:1.1.4
 COPY . /app
 WORKDIR /app
 EXPOSE 8080

--- a/Google.Cloud.Diagnostics.Debug.TestApp/Google.Cloud.Diagnostics.Debug.TestApp.csproj
+++ b/Google.Cloud.Diagnostics.Debug.TestApp/Google.Cloud.Diagnostics.Debug.TestApp.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
   </ItemGroup>
 
+  <Target Name="CopyDockerfileOnPublish" AfterTargets="Publish">
+    <Copy SourceFiles="Dockerfile" DestinationFolder="$(PublishDir)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This will make testing the test app easier.

This also changes the tag to just use the most recent 1.1.4 image.