### PR TITLE
Downgrade Command Line Parser to the last stable version.

### DIFF
--- a/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
+++ b/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="1.9.71" />
     <PackageReference Include="Google.Api.Gax" Version="2.2.1" />
     <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta01" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />


### PR DESCRIPTION
This allows for better strict parsing and will ensure the agent fails earlier with better error messages.

Fixes #122