### PR TITLE
Explicitly use the portable debug type.

### DIFF
--- a/Google.Cloud.Diagnostics.Debug.IntegrationTests/Google.Cloud.Diagnostics.Debug.IntegrationTests.csproj
+++ b/Google.Cloud.Diagnostics.Debug.IntegrationTests/Google.Cloud.Diagnostics.Debug.IntegrationTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Google.Cloud.Diagnostics.Debug.TestApp/Google.Cloud.Diagnostics.Debug.TestApp.csproj
+++ b/Google.Cloud.Diagnostics.Debug.TestApp/Google.Cloud.Diagnostics.Debug.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Google.Cloud.Diagnostics.Debug.Tests/Google.Cloud.Diagnostics.Debug.Tests.csproj
+++ b/Google.Cloud.Diagnostics.Debug.Tests/Google.Cloud.Diagnostics.Debug.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
+++ b/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using the full debug type does not generate portable PDBs on windows.  We only support portable PDBs.