### PR TITLE
Small improvements to the integration and performance tests

### DIFF
--- a/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTestBase.cs
+++ b/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTestBase.cs
@@ -125,14 +125,15 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
                 {
                     // Allow the app a chance to start up as it may not start
                     // right away.
-                    for (int i = 0; i < 10; i++)
+                    int attempts = 10;
+                    for (int i = 0; i < attempts; i++)
                     {
                         try
                         {
                             client.GetAsync(AppUrlBase).Wait();
                             break;
                         }
-                        catch (AggregateException) when (i < 9)
+                        catch (AggregateException) when (i < attempts - 1)
                         {
                             Thread.Sleep(TimeSpan.FromSeconds(1));
                         }


### PR DESCRIPTION
- Set the wait time to 0 so we do not wait between polls to the debugger API
- Allow more time for start up, while this normally isn't needed it sometimes takes longer
- Do not throw if the app was shutdown when we try to force a shutdown.

Hopefully this will help with flaky tests.