### PR TITLE
Changes to how we build protobuf.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,13 @@ script:
   - ./run_unit_tests.sh
   
 cache:
-  # Wait 20 min for cache (these direcories are large.
+  # Wait 20 min for cache (these directories are large).
   timeout: 1200
   directories:
   - $TRAVIS_BUILD_DIR/googletest/googletest/make
   - $TRAVIS_BUILD_DIR/googletest/googlemock/make
   - $TRAVIS_BUILD_DIR/coreclr/bin/Product/Linux.x64.Debug
-  # TODO(talarico): Figure out a cleaner way to cache this.
-  - $TRAVIS_BUILD_DIR/protobuf
+  - $TRAVIS_BUILD_DIR/protobuf/src
 
 
 # TODO(talarico): Hack to get build working as the scripts are not setting this properly.

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -33,7 +33,6 @@ then
   cd $PROTOBUF_DIR
   ./autogen.sh
   ./configure
-  make
   sudo make install
 else
   echo "Skipping protobuf, it was already built."


### PR DESCRIPTION
 - No need to make the entire library just install, we don't care about other bits.
 - In travis only cache the src directory, this contains more then we need but to only grab the files that we want would require a very long list.  This at least reduces the files needed to cache.