### PR TITLE
Remove the .NET Core 1.0 runtime on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,6 @@ before_install:
   # Needed for our bits
   - sudo apt-get install llvm-3.9 clang-3.9
 
-# Install the .NET Core 1.0 runtime as that's what we test against
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main'
-      key_url: 'https://packages.microsoft.com/keys/microsoft.asc'
-    packages:
-    - dotnet-sharedframework-microsoft.netcore.app-1.0.5
-
 script:
   # Build dependencies
   - ./build-deps.sh


### PR DESCRIPTION
We use 2.0 now and the image comes with 2.0.  This should hopefully speed up the install portion of the travis runs.