### PR TITLE
Use a hanging get instead of polling for breakpoints.

### DIFF
--- a/Google.Cloud.Diagnostics.Debug.IntegrationTests/TestApplication.cs
+++ b/Google.Cloud.Diagnostics.Debug.IntegrationTests/TestApplication.cs
@@ -83,7 +83,6 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
                 ProjectId = ProjectId,
                 Debugger = Utils.GetDebugger(),
                 ApplicationStartCommand = GetStartCommand(),
-                WaitTime = 0,
             };
             Agent agent = new Agent(options);
             new Thread(() =>

--- a/Google.Cloud.Diagnostics.Debug.Tests/AgentOptionsTests.cs
+++ b/Google.Cloud.Diagnostics.Debug.Tests/AgentOptionsTests.cs
@@ -53,7 +53,6 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             Assert.Equal(_projectId, options.ProjectId);
             Assert.Null(options.ApplicationId);
             Assert.False(options.PropertyEvaluation);
-            Assert.Equal(2, options.WaitTime);
         }
 
         [Fact]

--- a/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Agent.cs
+++ b/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Agent.cs
@@ -99,7 +99,7 @@ namespace Google.Cloud.Diagnostics.Debug
                     {
                         server.WaitForConnection();
                         tcs.SetResult(true);
-                        server.StartActionLoop(TimeSpan.FromSeconds(_agentOptions.WaitTime), cancellationToken);
+                        server.StartActionLoop(TimeSpan.Zero, cancellationToken);
                     });
 
                     // TODO(talarico): Temporary solution: This will ensure the debugger shuts down. See #146.

--- a/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/AgentOptions.cs
+++ b/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/AgentOptions.cs
@@ -67,10 +67,6 @@ namespace Google.Cloud.Diagnostics.Debug
             HelpText = "If set, the debugger will evaluate object's properties.")]
         public bool PropertyEvaluation { get; set; }
 
-        [Option("wait-time", DefaultValue = 2, 
-            HelpText = "The amount of time to wait before checking for new breakpoints in seconds.")]
-        public int WaitTime { get; set; }
-
         [HelpOption]
         public string Usage() => HelpText.AutoBuild(
             this, (HelpText helpText) => HelpText.DefaultParsingErrorsHandler(this, helpText));
@@ -87,7 +83,6 @@ namespace Google.Cloud.Diagnostics.Debug
                 options.Version = GaxPreconditions.CheckNotNullOrEmpty(options.Version ?? GetVersion(), nameof(options.Version));
                 options.ProjectId = GaxPreconditions.CheckNotNullOrEmpty(options.ProjectId ?? GetProject(), nameof(options.ProjectId));
                 options.Debugger = GaxPreconditions.CheckNotNullOrEmpty(options.Debugger ?? GetDebugger(), nameof(options.Debugger));
-                GaxPreconditions.CheckArgumentRange(options.WaitTime, nameof(options.WaitTime), 0, int.MaxValue);
 
                 if (!File.Exists(options.Debugger))
                 {

--- a/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/IDebuggerClient.cs
+++ b/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/IDebuggerClient.cs
@@ -28,7 +28,7 @@ namespace Google.Cloud.Diagnostics.Debug
         void Register();
 
         /// <summary>
-        /// Get a list of active breakpoints.
+        /// Get a list of active breakpoints. Blocks until the active breakpoints have changed.
         /// </summary>
         /// <exception cref="DebuggeeDisabledException">If the debuggee should be disabled.</exception>
         IEnumerable<StackdriverBreakpoint> ListBreakpoints();


### PR DESCRIPTION
This is much more efficient and is the recommended method by the debugger team.

Fixes #75