### PR TITLE
Add an explicit dependency on Google.Apis.Auth 1.32.2

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/Google.Cloud.Diagnostics.Debug.IntegrationTests.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/Google.Cloud.Diagnostics.Debug.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
     <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta01" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.PerformanceTests/Google.Cloud.Diagnostics.Debug.PerformanceTests.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.PerformanceTests/Google.Cloud.Diagnostics.Debug.PerformanceTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.TestApp/Google.Cloud.Diagnostics.Debug.TestApp.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.TestApp/Google.Cloud.Diagnostics.Debug.TestApp.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/Google.Cloud.Diagnostics.Debug.Tests.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/Google.Cloud.Diagnostics.Debug.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
     <PackageReference Include="Google.Api.Gax" Version="2.2.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
     <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta01" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.5.1" />


### PR DESCRIPTION
This ensures we won't hit https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/1394