### PR TITLE
Fix compilation of antlr files

### DIFF
--- a/third_party/antlr/lib/cpp/antlr/ANTLRException.hpp
+++ b/third_party/antlr/lib/cpp/antlr/ANTLRException.hpp
@@ -12,6 +12,8 @@
 #include <antlr/config.hpp>
 #include <antlr/DynamicCast.hpp>
 
+using std::string;
+
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif

--- a/third_party/antlr/lib/cpp/antlr/AST.hpp
+++ b/third_party/antlr/lib/cpp/antlr/AST.hpp
@@ -148,7 +148,7 @@ extern ANTLR_API RefAST nullAST;
 extern ANTLR_API AST* const nullASTptr;
 
 #ifdef NEEDS_OPERATOR_LESS_THAN
-inline operator<(RefAST l,RefAST r); // {return true;}
+inline bool operator<(RefAST l,RefAST r); // {return true;}
 #endif
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE

--- a/third_party/antlr/lib/cpp/antlr/CharScanner.hpp
+++ b/third_party/antlr/lib/cpp/antlr/CharScanner.hpp
@@ -11,8 +11,9 @@
 #include <antlr/config.hpp>
 
 #include <stdio.h>
-#include <strings.h>
+#include <string>
 #include <map>
+#include <functional>
 
 #ifdef HAS_NOT_CCTYPE_H
 #include <ctype.h>
@@ -537,7 +538,7 @@ inline bool CharScannerLiteralsLess::operator() (const ANTLR_USE_NAMESPACE(std)s
 	else
 	{
 #ifdef NO_STRCASECMP
-		return (stricmp(x.c_str(),y.c_str())<0);
+		return (_stricmp(x.c_str(),y.c_str())<0);
 #else
 		return (strcasecmp(x.c_str(),y.c_str())<0);
 #endif

--- a/third_party/antlr/lib/cpp/antlr/CommonToken.hpp
+++ b/third_party/antlr/lib/cpp/antlr/CommonToken.hpp
@@ -12,6 +12,8 @@
 #include <antlr/Token.hpp>
 #include <string>
 
+using std::string;
+
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif

--- a/third_party/antlr/lib/cpp/antlr/String.hpp
+++ b/third_party/antlr/lib/cpp/antlr/String.hpp
@@ -11,6 +11,8 @@
 #include <antlr/config.hpp>
 #include <string>
 
+using std::string;
+
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif

--- a/third_party/antlr/lib/cpp/antlr/Token.hpp
+++ b/third_party/antlr/lib/cpp/antlr/Token.hpp
@@ -12,6 +12,8 @@
 #include <antlr/RefCount.hpp>
 #include <string>
 
+using std::string;
+
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
@@ -74,7 +76,7 @@ private:
 };
 
 #ifdef NEEDS_OPERATOR_LESS_THAN
-inline operator<(RefToken l,RefToken r); //{return true;}
+inline bool operator<(RefToken l,RefToken r); //{return true;}
 #endif
 
 extern ANTLR_API RefToken nullToken;

--- a/third_party/antlr/lib/cpp/antlr/config.hpp
+++ b/third_party/antlr/lib/cpp/antlr/config.hpp
@@ -10,7 +10,7 @@
 
 // We assume std::string is defined in global namespace.
 #include <memory>
-using std::string;
+#include <string>
 
 /*
  * Just a simple configuration file to differentiate between the
@@ -43,13 +43,13 @@ using std::string;
 # pragma warning( disable : 4786 )
 
 // For the DLL support contributed by Stephen Naughton
-# ifdef ANTLR_EXPORTS
+//# ifdef ANTLR_EXPORTS
 #	undef ANTLR_API
 #	define ANTLR_API __declspec(dllexport)
-# else
-#	undef ANTLR_API
-#	define ANTLR_API __declspec(dllimport)
-# endif
+//# else
+//#	undef ANTLR_API
+//#	define ANTLR_API __declspec(dllimport)
+//# endif
 
 // Now, some defines for shortcomings in the MS compiler:
 //

--- a/third_party/antlr/lib/cpp/src/String.cpp
+++ b/third_party/antlr/lib/cpp/src/String.cpp
@@ -23,7 +23,7 @@ ANTLR_C_USING(sprintf)
 string operator+( const string& lhs, const int rhs )
 {
 	char tmp[100];
-	sprintf(tmp,"%d",rhs);
+	sprintf_s(tmp,"%d",rhs);
 	return lhs+tmp;
 }
 


### PR DESCRIPTION
These errors are because these methods are deprecated in the C++ version we are using.