### PR TITLE
Fix old TODO about MaxAllowedServerInstances

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/NamedPipeServer.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/NamedPipeServer.cs
@@ -36,8 +36,7 @@ namespace Google.Cloud.Diagnostics.Debug
             _server = new NamedPipeServerStream(
                pipeName: GaxPreconditions.CheckNotNullOrEmpty(pipeName, nameof(pipeName)),
                direction: PipeDirection.InOut,
-               // TODO(talarico): This should be NamedPipeServerStream.MaxAllowedServerInstance but it's not public.
-               maxNumberOfServerInstances: -1,
+               maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
                transmissionMode: PipeTransmissionMode.Byte,
                options: PipeOptions.Asynchronous);
             _pipe = new NamedPipe(_server);


### PR DESCRIPTION
This was made possible to fix when we upgraded underlying packages.