### PR TITLE
Remove the RemoveBreakpoint function in the BreakpointManager

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointManagerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointManagerTests.cs
@@ -124,30 +124,6 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
         }
 
         [Fact]
-        public void RemoveBreakpoint()
-        {
-            var breakpoints = CreateBreakpoints(1);
-            _manager.UpdateBreakpoints(breakpoints);
-            _manager.RemoveBreakpoint(breakpoints.Single());
-
-            var response = _manager.UpdateBreakpoints(_emptyList);
-            Assert.Empty(response.New);
-            Assert.Empty(response.Removed);
-        }
-
-        [Fact]
-        public void RemoveBreakpoint_NoEffect()
-        {
-            var breakpoints = CreateBreakpoints(2);
-            _manager.UpdateBreakpoints(breakpoints.GetRange(0, 1));
-            _manager.RemoveBreakpoint(breakpoints[1]);
-
-            var response = _manager.UpdateBreakpoints(_emptyList);
-            Assert.Empty(response.New);
-            Assert.Equal(breakpoints[0], response.Removed.Single());
-        }
-
-        [Fact]
         public void GetBreakpointId()
         {
             var breakpoints = CreateBreakpoints(1);

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/BreakpointManager.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/BreakpointManager.cs
@@ -94,18 +94,6 @@ namespace Google.Cloud.Diagnostics.Debug
         }
 
         /// <summary>
-        /// Remove a breakpoint from the manager.
-        /// </summary>
-        /// <param name="breakpoint">The breakpoint to remove.</param>
-        public void RemoveBreakpoint(StackdriverBreakpoint breakpoint)
-        {
-            lock (_mutex)
-            {
-                _breakpointDictionary.Remove(breakpoint.GetLocationIdentifier());
-            }
-        }
-
-        /// <summary>
         /// Gets the breakpoint id from the manager based on the breakpoint location.
         /// If the list does not contain
         /// Note: This is needed as the debugger does not pay attention to breakpoint ids

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/BreakpointReadActionServer.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/BreakpointReadActionServer.cs
@@ -49,7 +49,6 @@ namespace Google.Cloud.Diagnostics.Debug
             StackdriverBreakpoint breakpoint = readBreakpoint.Convert();
             breakpoint.IsFinalState = true;
             breakpoint.Id = _breakpointManager.GetBreakpointId(breakpoint) ?? breakpoint.Id;
-            _breakpointManager.RemoveBreakpoint(breakpoint);
             _client.UpdateBreakpoint(breakpoint);
         }
     }


### PR DESCRIPTION
This is no longer needed as the breakpoint will be removed when the list call is made in the write server and will lead to breakpoints staying in the debugger when they should be removed.