### PR TITLE
Fix C# unit tests

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointManagerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointManagerTests.cs
@@ -73,22 +73,25 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
         }
 
         [Fact]
-        public void UpdateBreakpoints_IgnoreDuplicateBreakpointsBySource()
+        public void UpdateBreakpoints_ShouldNotIgnoreDuplicateBreakpointsBySource()
         {
             var breakpoints = CreateBreakpoints(2);
             var response = _manager.UpdateBreakpoints(breakpoints);
 
             Assert.Equal(2, response.New.Count());
 
+            // Now create 2 breakpoints with different id but same location.
             foreach (var breakpoint in breakpoints)
             {
-                breakpoint.Id = "" + (Int32.Parse(breakpoint.Id) * 2);
+                // Have to plus 1 because if breakpoint id is 0, then
+                // we get the same breakpoint id.
+                breakpoint.Id = "" + ((Int32.Parse(breakpoint.Id) + 1)* 2);
             }
 
             response = _manager.UpdateBreakpoints(breakpoints);
 
-            Assert.Empty(response.New);
-            Assert.Empty(response.Removed);
+            Assert.Equal(2, response.New.Count());
+            Assert.Equal(2, response.Removed.Count());
         }
 
         [Fact]

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointWriteActionServerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointWriteActionServerTests.cs
@@ -94,8 +94,6 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             _mockDebuggerClient.Verify(c => c.ListBreakpoints(), Times.Once);
             _mockDebuggerClient.Verify(c => c.UpdateBreakpoint(
                 Match.Create(GetErrorMatcher("0", Messages.LogPointNotSupported))), Times.Once);
-            _mockBreakpointServer.Verify(s => s.WriteBreakpointAsync(
-                It.IsAny<Breakpoint>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -123,9 +121,8 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             _mockDebuggerClient.Setup(c => c.ListBreakpoints()).Returns(breakpoints);
             _server.MainAction();
 
-            _mockDebuggerClient.Verify(c => c.UpdateBreakpoint(Match.Create(GetErrorMatcher("2"))), Times.Once);
             _mockBreakpointServer.Verify(s => s.WriteBreakpointAsync(
-                It.IsAny<Breakpoint>(), It.IsAny<CancellationToken>()), Times.Exactly(4));
+                It.IsAny<Breakpoint>(), It.IsAny<CancellationToken>()), Times.Exactly(5));
 
             _mockDebuggerClient.Reset();
             _mockBreakpointServer.Reset();


### PR DESCRIPTION
These tests fail when conditional breakpoints are introduced.