### PR TITLE
Remove ICorDebugILFrame from dbg_stack_frame

### DIFF
--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_breakpoint.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_breakpoint.cc
@@ -156,7 +156,13 @@ HRESULT DbgBreakpoint::EvaluateCondition(DbgStackFrame *stack_frame,
     return E_FAIL;
   }
 
-  HRESULT hr = compiled_expression.evaluator->Compile(stack_frame, &std::cerr);
+  CComPtr<ICorDebugILFrame> active_frame;
+  HRESULT hr = eval_coordinator->GetActiveDebugFrame(&active_frame);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  hr = compiled_expression.evaluator->Compile(stack_frame, active_frame, &std::cerr);
   if (FAILED(hr)) {
     return hr;
   }

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.h
@@ -66,13 +66,14 @@ class DbgStackFrame {
   // Gets a local variable or method arguments with name
   // variable_name.
   HRESULT GetLocalVariable(const std::string &variable_name,
-                           std::unique_ptr<DbgObject> *dbg_object,
+                           std::shared_ptr<DbgObject> *dbg_object,
                            std::ostream *err_stream);
 
   // Gets out any field or auto-implemented property with the name
   // member_name of the class this frame is in.
   HRESULT GetFieldAndAutoPropFromFrame(const std::string &member_name,
-                                       std::unique_ptr<DbgObject> *dbg_object,
+                                       std::shared_ptr<DbgObject> *dbg_object,
+                                       ICorDebugILFrame *debug_frame,
                                        std::ostream *err_stream);
 
   // Gets out property with the name property_name of the class
@@ -184,9 +185,6 @@ class DbgStackFrame {
   // Returns true if the method this frame is in is a static method.
   bool IsStaticMethod() { return is_static_method_; }
 
-  // Returns the ICorDebugFrame this frame is in.
-  HRESULT GetFrame(ICorDebugILFrame **debug_frame);
-
   // Gets the ICorDebugFunction that corresponds with method represented by
   // method_info in the class class_token. This function will
   // also check the methods against the arguments vector to
@@ -205,6 +203,7 @@ class DbgStackFrame {
 
   // Extract out generic type parameters for the class the frame is in.
   HRESULT GetClassGenericTypeParameters(
+      ICorDebugILFrame *debug_frame,
       std::vector<CComPtr<ICorDebugType>> *debug_types);
 
  private:
@@ -297,9 +296,6 @@ class DbgStackFrame {
   // The module this stack frame is in.
   CComPtr<ICorDebugModule> debug_module_;
 
-  // The frame this stack frame is in.
-  CComPtr<ICorDebugILFrame> debug_frame_;
-
   // Dictionary whose key is class name and whose value
   // is the metadata token mdTypeDef of that class.
   std::map<std::string, mdTypeDef> type_def_dict_;
@@ -315,10 +311,6 @@ class DbgStackFrame {
 
   // True if type_def_dict_ and type_ref_dict_ have been populated.
   bool type_dict_populated_ = false;
-
-  // MetaData for local variables in this frame.
-  std::vector<google_cloud_debugger_portable_pdb::LocalVariableInfo>
-      local_variables_info_;
 };
 
 }  //  namespace google_cloud_debugger

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/eval_coordinator.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/eval_coordinator.cc
@@ -203,6 +203,26 @@ HRESULT EvalCoordinator::GetActiveDebugThread(ICorDebugThread **debug_thread) {
   return E_FAIL;
 }
 
+HRESULT EvalCoordinator::GetActiveDebugFrame(ICorDebugILFrame **debug_il_frame) {
+  if (!debug_il_frame) {
+    return E_INVALIDARG;
+  }
+
+  if (active_debug_thread_) {
+    CComPtr<ICorDebugFrame> debug_frame;
+    HRESULT hr = active_debug_thread_->GetActiveFrame(&debug_frame);
+    if (FAILED(hr)) {
+      cerr << "Failed to get active frame.";
+      return hr;
+    }
+
+    return debug_frame->QueryInterface(__uuidof(ICorDebugILFrame),
+                                       reinterpret_cast<void **>(debug_il_frame));
+  }
+
+  return E_FAIL;
+}
+
 BOOL EvalCoordinator::WaitingForEval() {
   lock_guard<mutex> lk(mutex_);
   return waiting_for_eval_;

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/eval_coordinator.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/eval_coordinator.h
@@ -92,6 +92,9 @@ class EvalCoordinator : public IEvalCoordinator {
   // Returns the active debug thread.
   HRESULT GetActiveDebugThread(ICorDebugThread **debug_thread) override;
 
+  // Returns the active debug thread.
+  HRESULT GetActiveDebugFrame(ICorDebugILFrame **debug_frame) override;
+
   // Returns true if we are waiting for an evaluation result.
   BOOL WaitingForEval() override;
 

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/i_eval_coordinator.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/i_eval_coordinator.h
@@ -100,6 +100,9 @@ class IEvalCoordinator {
   // Returns the active debug thread.
   virtual HRESULT GetActiveDebugThread(ICorDebugThread **debug_thread) = 0;
 
+  // Returns the active debug frame.
+  virtual HRESULT GetActiveDebugFrame(ICorDebugILFrame **debug_frame) = 0;
+
   // Returns true if we are waiting for an evaluation result.
   virtual BOOL WaitingForEval() = 0;
 

--- a/src/google_cloud_debugger/google_cloud_debugger_test/i_eval_coordinator_mock.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_test/i_eval_coordinator_mock.h
@@ -51,6 +51,8 @@ class IEvalCoordinatorMock : public google_cloud_debugger::IEvalCoordinator {
 
   MOCK_METHOD1(GetActiveDebugThread, HRESULT(ICorDebugThread **debug_thread));
 
+  MOCK_METHOD1(GetActiveDebugFrame, HRESULT(ICorDebugILFrame **debug_frame));
+
   MOCK_METHOD0(WaitingForEval, BOOL());
 
   MOCK_METHOD1(SetPropertyEvaluation, void(BOOL eval));

--- a/third_party/cloud-debug-java/array_expression_evaluator.cc
+++ b/third_party/cloud-debug-java/array_expression_evaluator.cc
@@ -32,13 +32,15 @@ IndexerAccessExpressionEvaluator::IndexerAccessExpressionEvaluator(
 
 HRESULT IndexerAccessExpressionEvaluator::Compile(
     DbgStackFrame *stack_frame,
+    ICorDebugILFrame *debug_frame,
     std::ostream *err_stream) {
-  HRESULT hr = source_collection_->Compile(stack_frame, err_stream);
+  HRESULT hr = source_collection_->Compile(stack_frame, debug_frame,
+                                           err_stream);
   if (FAILED(hr)) {
     return hr;
   }
 
-  hr = source_index_->Compile(stack_frame, err_stream);
+  hr = source_index_->Compile(stack_frame, debug_frame, err_stream);
   if (FAILED(hr)) {
     return hr;
   }

--- a/third_party/cloud-debug-java/array_expression_evaluator.h
+++ b/third_party/cloud-debug-java/array_expression_evaluator.h
@@ -36,6 +36,7 @@ class IndexerAccessExpressionEvaluator : public ExpressionEvaluator {
   // to do this for any expression that has get_Item() function.
   HRESULT Compile(
       DbgStackFrame *stack_frame,
+      ICorDebugILFrame *debug_frame,
       std::ostream *err_stream) override;
 
   // Returns the static type that the expression compiles to.

--- a/third_party/cloud-debug-java/binary_expression_evaluator.cc
+++ b/third_party/cloud-debug-java/binary_expression_evaluator.cc
@@ -121,14 +121,15 @@ BinaryExpressionEvaluator::BinaryExpressionEvaluator(
 }
 
 HRESULT BinaryExpressionEvaluator::Compile(DbgStackFrame *readers_factory,
+                                           ICorDebugILFrame *debug_frame,
                                            std::ostream *error_stream) {
   HRESULT hr;
-  hr = arg1_->Compile(readers_factory, error_stream);
+  hr = arg1_->Compile(readers_factory, debug_frame, error_stream);
   if (FAILED(hr)) {
     return hr;
   }
 
-  hr = arg2_->Compile(readers_factory, error_stream);
+  hr = arg2_->Compile(readers_factory, debug_frame, error_stream);
   if (FAILED(hr)) {
     return hr;
   }

--- a/third_party/cloud-debug-java/binary_expression_evaluator.h
+++ b/third_party/cloud-debug-java/binary_expression_evaluator.h
@@ -38,6 +38,7 @@ class BinaryExpressionEvaluator : public ExpressionEvaluator {
   // and the binary operator, compiles and sets the static type of this expression.
   HRESULT Compile(
       DbgStackFrame* readers_factory,
+      ICorDebugILFrame *debug_frame,
       std::ostream* err_stream) override;
 
   // Returns the static type of the expression.

--- a/third_party/cloud-debug-java/conditional_operator_evaluator.cc
+++ b/third_party/cloud-debug-java/conditional_operator_evaluator.cc
@@ -35,18 +35,19 @@ ConditionalOperatorEvaluator::ConditionalOperatorEvaluator(
 
 
 HRESULT ConditionalOperatorEvaluator::Compile(
-    DbgStackFrame* stack_frame, std::ostream *err_stream) {
-  HRESULT hr = condition_->Compile(stack_frame, err_stream);
+    DbgStackFrame* stack_frame, ICorDebugILFrame *debug_frame,
+    std::ostream *err_stream) {
+  HRESULT hr = condition_->Compile(stack_frame, debug_frame, err_stream);
   if (FAILED(hr)) {
     return hr;
   }
 
-  hr = if_true_->Compile(stack_frame, err_stream);
+  hr = if_true_->Compile(stack_frame, debug_frame, err_stream);
   if (FAILED(hr)) {
     return hr;
   }
 
-  hr = if_false_->Compile(stack_frame, err_stream);
+  hr = if_false_->Compile(stack_frame, debug_frame, err_stream);
   if (FAILED(hr)) {
     return hr;
   }

--- a/third_party/cloud-debug-java/conditional_operator_evaluator.h
+++ b/third_party/cloud-debug-java/conditional_operator_evaluator.h
@@ -35,7 +35,8 @@ class ConditionalOperatorEvaluator : public ExpressionEvaluator {
   // the helper functions CompileBoolean, CompileNumeric
   // and CompileObjects.
   HRESULT Compile(
-      DbgStackFrame *stack_frame, std::ostream *err_stream) override;
+      DbgStackFrame *stack_frame, ICorDebugILFrame *debug_frame,
+      std::ostream *err_stream) override;
 
   // Returns the static type of this expression, determined by
   // the true and false expression.

--- a/third_party/cloud-debug-java/expression_evaluator.h
+++ b/third_party/cloud-debug-java/expression_evaluator.h
@@ -45,7 +45,8 @@ class ExpressionEvaluator {
   // phase to improve performance of repeatedly evaluated expressions and to
   // minimize amount of time that the debugged thread is paused on breakpoint.
   virtual HRESULT Compile(
-      DbgStackFrame *stack_frame, std::ostream *err_stream) = 0;
+      DbgStackFrame *stack_frame, ICorDebugILFrame *debug_frame,
+      std::ostream *err_stream) = 0;
 
   // Gets the type of the expression as it is known at compile time. If the
   // code is correct, the runtime type will be the same as compile time type.

--- a/third_party/cloud-debug-java/field_evaluator.h
+++ b/third_party/cloud-debug-java/field_evaluator.h
@@ -36,7 +36,7 @@ class FieldEvaluator : public ExpressionEvaluator {
                  std::string identifier_name, std::string possible_class_name,
                  std::string field_name);
 
-  HRESULT Compile(DbgStackFrame *stack_frame,
+  HRESULT Compile(DbgStackFrame *stack_frame, ICorDebugILFrame *debug_frame,
                   std::ostream *err_stream) override;
 
   const TypeSignature &GetStaticType() const override { return result_type_; }
@@ -50,6 +50,7 @@ class FieldEvaluator : public ExpressionEvaluator {
   // and then uses that to extract out information about field
   // field_name_.
   HRESULT CompileUsingInstanceSource(DbgStackFrame *stack_frame,
+                                     ICorDebugILFrame *debug_frame,
                                      std::ostream *err_stream);
 
   // Tries to use possible_class_name_ to extract out information
@@ -102,9 +103,6 @@ class FieldEvaluator : public ExpressionEvaluator {
 
   // Module that contains the class this field is in.
   CComPtr<ICorDebugModule> debug_module_;
-
-  // Gets the frame this field is in.
-  CComPtr<ICorDebugILFrame> debug_frame_;
 
   DISALLOW_COPY_AND_ASSIGN(FieldEvaluator);
 };

--- a/third_party/cloud-debug-java/identifier_evaluator.cc
+++ b/third_party/cloud-debug-java/identifier_evaluator.cc
@@ -27,31 +27,29 @@ IdentifierEvaluator::IdentifierEvaluator(std::string identifier_name)
 
 HRESULT IdentifierEvaluator::Compile(
     DbgStackFrame *stack_frame,
+    ICorDebugILFrame *debug_frame,
     std::ostream *err_stream) {
   // Case 1: this is a local variable.
-  std::unique_ptr<DbgObject> identifier_obj;
   HRESULT hr = stack_frame->GetLocalVariable(identifier_name_,
-    &identifier_obj, err_stream);
+    &identifier_object_, err_stream);
   if (FAILED(hr)) {
     return hr;
   }
 
   // S_FALSE means there is no match.
   if (SUCCEEDED(hr) && hr != S_FALSE) {
-    identifier_object_ = std::move(identifier_obj);
     return identifier_object_->GetTypeSignature(&result_type_);
   }
 
   // Case 2: static and non-static fields and auto-implemented properties.
   hr = stack_frame->GetFieldAndAutoPropFromFrame(identifier_name_,
-    &identifier_obj, err_stream);
+    &identifier_object_, debug_frame, err_stream);
   if (FAILED(hr)) {
     return hr;
   }
 
   // S_FALSE means there is no match.
   if (SUCCEEDED(hr) && hr != S_FALSE) {
-    identifier_object_ = std::move(identifier_obj);
     return identifier_object_->GetTypeSignature(&result_type_);
   }
 

--- a/third_party/cloud-debug-java/identifier_evaluator.h
+++ b/third_party/cloud-debug-java/identifier_evaluator.h
@@ -32,6 +32,7 @@ class IdentifierEvaluator : public ExpressionEvaluator {
 
   virtual HRESULT Compile(
       DbgStackFrame *stack_frame,
+      ICorDebugILFrame *debug_frame,
       std::ostream *err_stream) override;
 
   const TypeSignature& GetStaticType() const override { return result_type_; }

--- a/third_party/cloud-debug-java/literal_evaluator.h
+++ b/third_party/cloud-debug-java/literal_evaluator.h
@@ -31,7 +31,8 @@ class LiteralEvaluator : public ExpressionEvaluator {
   }
 
   virtual HRESULT Compile(
-      DbgStackFrame* stack_frame, std::ostream *err_stream) override {
+      DbgStackFrame* stack_frame, ICorDebugILFrame *debug_frame,
+      std::ostream *err_stream) override {
     return S_OK;
   }
 

--- a/third_party/cloud-debug-java/method_call_evaluator.h
+++ b/third_party/cloud-debug-java/method_call_evaluator.h
@@ -43,6 +43,7 @@ class MethodCallEvaluator : public ExpressionEvaluator {
   // If instance_source_ is not null, search for method with name
   // method_name_ in this class.
   HRESULT Compile(DbgStackFrame *stack_frame,
+                  ICorDebugILFrame *debug_frame,
                   std::ostream *err_stream) override;
 
   const TypeSignature &GetStaticType() const override { return return_type_; }

--- a/third_party/cloud-debug-java/string_evaluator.h
+++ b/third_party/cloud-debug-java/string_evaluator.h
@@ -31,7 +31,8 @@ class StringEvaluator : public ExpressionEvaluator {
 
   // Nothing to do in Compile.
   HRESULT Compile(
-      DbgStackFrame* readers_factory, std::ostream *err_stream) override {
+      DbgStackFrame* readers_factory, ICorDebugILFrame *debug_frame,
+      std::ostream *err_stream) override {
     return S_OK;
   };
 

--- a/third_party/cloud-debug-java/type_cast_operator_evaluator.cc
+++ b/third_party/cloud-debug-java/type_cast_operator_evaluator.cc
@@ -34,8 +34,9 @@ TypeCastOperatorEvaluator::TypeCastOperatorEvaluator(
 }
 
 HRESULT TypeCastOperatorEvaluator::Compile(DbgStackFrame *stack_frame,
+                                           ICorDebugILFrame *debug_frame,
                                            std::ostream *err_stream) {
-  HRESULT hr = source_->Compile(stack_frame, err_stream);
+  HRESULT hr = source_->Compile(stack_frame, debug_frame, err_stream);
   if (FAILED(hr)) {
     return hr;
   }

--- a/third_party/cloud-debug-java/type_cast_operator_evaluator.h
+++ b/third_party/cloud-debug-java/type_cast_operator_evaluator.h
@@ -42,6 +42,7 @@ class TypeCastOperatorEvaluator : public ExpressionEvaluator {
   // either of them is a base class of the other. If not, this function will
   // fail. Otherwise, sets result_type_ to target_type_ and do nothing.
   HRESULT Compile(DbgStackFrame *stack_frame,
+                  ICorDebugILFrame *debug_frame,
                   std::ostream *err_stream) override;
 
   // Returns the static type of the expression.

--- a/third_party/cloud-debug-java/unary_expression_evaluator.cc
+++ b/third_party/cloud-debug-java/unary_expression_evaluator.cc
@@ -31,8 +31,9 @@ UnaryExpressionEvaluator::UnaryExpressionEvaluator(
 }
 
 HRESULT UnaryExpressionEvaluator::Compile(DbgStackFrame *stack_frame,
+                                          ICorDebugILFrame *debug_frame,
                                           std::ostream *err_stream) {
-  HRESULT hr = arg_->Compile(stack_frame, err_stream);
+  HRESULT hr = arg_->Compile(stack_frame, debug_frame, err_stream);
   if (FAILED(hr)) {
     *err_stream << kFailedToCompileFirstSubExpr;
     return hr;

--- a/third_party/cloud-debug-java/unary_expression_evaluator.h
+++ b/third_party/cloud-debug-java/unary_expression_evaluator.h
@@ -37,6 +37,7 @@ class UnaryExpressionEvaluator : public ExpressionEvaluator {
   // evaluate the expressoin and assign that to computer_.
   HRESULT Compile(
       DbgStackFrame *stack_frame,
+      ICorDebugILFrame *debug_frame,
       std::ostream *err_stream) override;
 
   // Returns the static type of the expression.


### PR DESCRIPTION
I have to remove this because ICorDebugILFrame can be invalidated when the application continues (like when we evaluate a method). So it's not safe to store it.