### PR TITLE
Refactor DbgObject code

### DIFF
--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_array.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_array.h
@@ -28,8 +28,11 @@ class EvalCoordinator;
 // This includes multi-dimensional as well as jagged arrays.
 class DbgArray : public DbgReferenceObject {
  public:
-  DbgArray(ICorDebugType *debug_type, int depth)
-      : DbgReferenceObject(debug_type, depth) {}
+  DbgArray(ICorDebugType *debug_type, int depth,
+           std::shared_ptr<ICorDebugHelper> debug_helper,
+           std::shared_ptr<IDbgObjectFactory> object_factory)
+      : DbgReferenceObject(debug_type, depth, debug_helper,
+                           object_factory) {}
 
   // Retrieves information about array rank, array dimensions, array type and
   // creates a strong handle to the array.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_breakpoint.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_breakpoint.cc
@@ -144,7 +144,8 @@ bool DbgBreakpoint::TrySetBreakpoint(
 }
 
 HRESULT DbgBreakpoint::EvaluateCondition(DbgStackFrame *stack_frame,
-    IEvalCoordinator *eval_coordinator) {
+    IEvalCoordinator *eval_coordinator,
+    IDbgObjectFactory *obj_factory) {
   if (condition_.empty()) {
     evaluated_condition_ = true;
     return S_OK;
@@ -175,7 +176,7 @@ HRESULT DbgBreakpoint::EvaluateCondition(DbgStackFrame *stack_frame,
 
   std::shared_ptr<DbgObject> condition_result;
   hr = compiled_expression.evaluator->Evaluate(&condition_result,
-      eval_coordinator, &std::cerr);
+      eval_coordinator, obj_factory, &std::cerr);
   if (FAILED(hr)) {
     return hr;
   }

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_breakpoint.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_breakpoint.h
@@ -34,6 +34,7 @@ namespace google_cloud_debugger {
 class IEvalCoordinator;
 class IStackFrameCollection;
 class DbgStackFrame;
+class IDbgObjectFactory;
 
 // This class represents a breakpoint in the Debugger.
 // To use the class, call the Initialize method to populate the
@@ -147,7 +148,8 @@ class DbgBreakpoint {
   // Evaluates condition condition_ using the provided stack frame
   // and eval coordinator. Sets the result to evaluated_condition_.
   HRESULT EvaluateCondition(DbgStackFrame *stack_frame,
-                            IEvalCoordinator *eval_coordinator);
+                            IEvalCoordinator *eval_coordinator,
+                            IDbgObjectFactory *obj_factory);
 
   // Populate a Breakpoint proto using this breakpoint information.
   // StackFrameCollection stack_frames and EvalCoordinator eval_coordinator

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_builtin_collection.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_builtin_collection.cc
@@ -22,6 +22,7 @@
 #include "class_names.h"
 #include "dbg_array.h"
 #include "i_cor_debug_helper.h"
+#include "i_dbg_object_factory.h"
 #include "i_eval_coordinator.h"
 #include "variable_wrapper.h"
 
@@ -234,8 +235,8 @@ HRESULT DbgBuiltinCollection::PopulateHashSetOrDictionary(
     // So a dictionary entry is essentially the same as a set slot except
     // that the dictionary entry has a key.
     unique_ptr<DbgObject> slot_item_obj;
-    hr = CreateDbgObject(array_item, GetCreationDepth(), &slot_item_obj,
-                         GetErrorStream());
+    hr = object_factory_->CreateDbgObject(array_item, GetCreationDepth(),
+                                          &slot_item_obj, GetErrorStream());
     if (FAILED(hr)) {
       WriteError("Failed to create DbgObject for item at index " +
                  std::to_string(index));
@@ -268,7 +269,8 @@ HRESULT DbgBuiltinCollection::PopulateHashSetOrDictionary(
 
     // Gets the underlying DbgObject that represents value field.
     shared_ptr<DbgObject> value_obj = nullptr;
-    hr = slot_item->GetNonStaticField(kHashSetAndDictValueFieldName, &value_obj);
+    hr =
+        slot_item->GetNonStaticField(kHashSetAndDictValueFieldName, &value_obj);
     if (FAILED(hr)) {
       WriteError("Failed to evaluate the value of item at index " +
                  std::to_string(index));

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_builtin_collection.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_builtin_collection.h
@@ -26,8 +26,10 @@ namespace google_cloud_debugger {
 // Dictionary).
 class DbgBuiltinCollection : public DbgClass {
  public:
-  DbgBuiltinCollection(ICorDebugType *debug_type, int depth)
-      : DbgClass(debug_type, depth) {}
+  DbgBuiltinCollection(ICorDebugType *debug_type, int depth,
+                       std::shared_ptr<ICorDebugHelper> debug_helper,
+                       std::shared_ptr<IDbgObjectFactory> obj_factory)
+      : DbgClass(debug_type, depth, debug_helper, obj_factory) {}
 
   HRESULT PopulateMembers(
       google::cloud::diagnostics::debug::Variable *variable_proto,
@@ -37,10 +39,9 @@ class DbgBuiltinCollection : public DbgClass {
  protected:
   // Stores the items in the collection depending on whether
   // this is a list, set or dictionary.
-  HRESULT ProcessClassMembersHelper(
-      ICorDebugValue *debug_value,
-      ICorDebugClass *debug_class,
-      IMetaDataImport *metadata_import) override;
+  HRESULT ProcessClassMembersHelper(ICorDebugValue *debug_value,
+                                    ICorDebugClass *debug_class,
+                                    IMetaDataImport *metadata_import) override;
 
   // Populates variables with a field count (number of items in this hash set
   // or dictionary) and the members of this hash set or dictionary.
@@ -116,4 +117,4 @@ class DbgBuiltinCollection : public DbgClass {
 
 }  //  namespace google_cloud_debugger
 
-#endif  //  DBG_ENUM_H_
+#endif  //  DBG_BUILTIN_COLLECTION_H_

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.cc
@@ -15,7 +15,6 @@
 #include "dbg_enum.h"
 
 #include "class_names.h"
-#include "i_cor_debug_helper.h"
 #include "i_eval_coordinator.h"
 
 using google::cloud::diagnostics::debug::Variable;

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.h
@@ -26,7 +26,9 @@ namespace google_cloud_debugger {
 // (CorElementType as ELEMENT_TYPE_CLASS and ELEMENT_TYPE_VALUETYPE).
 class DbgEnum : public DbgClass {
  public:
-  DbgEnum(ICorDebugType *debug_type, int depth) : DbgClass(debug_type, depth) {}
+  DbgEnum(ICorDebugType *debug_type, int depth)
+      : DbgClass(debug_type, depth, std::shared_ptr<ICorDebugHelper>(),
+                 std::shared_ptr<IDbgObjectFactory>()) {}
 
   // Populate variable with the value of the enum.
   HRESULT PopulateValue(
@@ -34,8 +36,7 @@ class DbgEnum : public DbgClass {
 
   // Extracts out the enum value of this Enum class and processes
   // the fields of this enum.
-  HRESULT ProcessEnum(ICorDebugValue *debug_value,
-                      ICorDebugClass *debug_class,
+  HRESULT ProcessEnum(ICorDebugValue *debug_value, ICorDebugClass *debug_class,
                       IMetaDataImport *metadata_import);
 
  private:

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_null_object.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_null_object.h
@@ -15,8 +15,8 @@
 #ifndef DBG_NULL_OBJECT_H_
 #define DBG_NULL_OBJECT_H_
 
-#include "dbg_object.h"
 #include "class_names.h"
+#include "dbg_object.h"
 
 namespace google_cloud_debugger {
 class EvalCoordinator;
@@ -27,15 +27,16 @@ class EvalCoordinator;
 // the type to create it).
 class DbgNullObject : public DbgObject {
  public:
-  DbgNullObject(ICorDebugType *pType) : DbgObject(pType, 0) {}
+  DbgNullObject(ICorDebugType *pType)
+      : DbgObject(pType, 0, std::shared_ptr<ICorDebugHelper>()) {}
 
   // Inherited via DbgObject.
-  virtual void Initialize(ICorDebugValue * debug_value, BOOL is_null) override {}
+  virtual void Initialize(ICorDebugValue *debug_value, BOOL is_null) override {}
 
   // This should not be called because we cannot create a
   // ICorDebugValue that represents a null object.
   HRESULT GetICorDebugValue(ICorDebugValue **debug_value,
-    ICorDebugEval *debug_eval) override {
+                            ICorDebugEval *debug_eval) override {
     return E_NOTIMPL;
   }
 

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_reference_object.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_reference_object.cc
@@ -15,6 +15,7 @@
 #include "dbg_reference_object.h"
 
 #include "i_cor_debug_helper.h"
+#include "i_dbg_object_factory.h"
 
 namespace google_cloud_debugger {
 HRESULT DbgReferenceObject::GetNonStaticField(
@@ -29,7 +30,7 @@ HRESULT DbgReferenceObject::GetNonStaticField(
   // Dereferences the object to get ICorDebugObjectValue.
   BOOL is_null = FALSE;
   CComPtr<ICorDebugValue> debug_value;
-  hr = Dereference(object_handle_, &debug_value,
+  hr = debug_helper_->Dereference(object_handle_, &debug_value,
                    &is_null, GetErrorStream());
   if (FAILED(hr)) {
     return hr;
@@ -63,7 +64,7 @@ HRESULT DbgReferenceObject::GetNonStaticField(
   }
 
   CComPtr<IMetaDataImport> metadata_import;
-  hr = GetMetadataImportFromICorDebugClass(debug_class,
+  hr = debug_helper_->GetMetadataImportFromICorDebugClass(debug_class,
       &metadata_import, GetErrorStream());
   if (FAILED(hr)) {
     return hr;
@@ -73,7 +74,7 @@ HRESULT DbgReferenceObject::GetNonStaticField(
   bool is_static;
   PCCOR_SIGNATURE field_sig;
   ULONG field_sig_len = 0;
-  hr = GetFieldInfo(metadata_import, class_token,
+  hr = debug_helper_->GetFieldInfo(metadata_import, class_token,
       field_name, &field_def, &is_static, &field_sig,
       &field_sig_len, GetErrorStream());
   if (FAILED(hr)) {
@@ -92,7 +93,8 @@ HRESULT DbgReferenceObject::GetNonStaticField(
   }
 
   std::unique_ptr<DbgObject> dbg_object;
-  hr = DbgObject::CreateDbgObject(field_debug_value, GetCreationDepth() - 1,
+  hr = object_factory_->CreateDbgObject(field_debug_value,
+      GetCreationDepth() - 1,
       &dbg_object, GetErrorStream());
   if (FAILED(hr)) {
     return hr;

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_reference_object.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_reference_object.h
@@ -19,12 +19,19 @@
 
 namespace google_cloud_debugger {
 
+class IDbgObjectFactory;
+
 // This class represents a .NET object of reference type.
 class DbgReferenceObject : public DbgObject {
  public:
-  DbgReferenceObject(ICorDebugType *debug_type, int depth)
-      : DbgObject(debug_type, depth) {}
-   
+  // obj_factory is needed to create members of reference object.
+  DbgReferenceObject(ICorDebugType *debug_type, int depth,
+                     std::shared_ptr<ICorDebugHelper> debug_helper,
+                     std::shared_ptr<IDbgObjectFactory> obj_factory)
+      : DbgObject(debug_type, depth, debug_helper) {
+    object_factory_ = obj_factory;
+  }
+
   // Searches the object for non-static field field_name and returns
   // the value in field_value.
   virtual HRESULT GetNonStaticField(const std::string &field_name,
@@ -41,6 +48,8 @@ class DbgReferenceObject : public DbgObject {
   // Handle for the object.
   // Only applicable for class, array and string.
   CComPtr<ICorDebugHandleValue> object_handle_;
+
+  std::shared_ptr<IDbgObjectFactory> object_factory_;
 };
 
 }  //  namespace google_cloud_debugger

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.h
@@ -23,8 +23,6 @@
 
 #include "breakpoint.pb.h"
 #include "constants.h"
-#include "cor.h"
-#include "cordebug.h"
 #include "dbg_object.h"
 #include "document_index.h"
 
@@ -36,6 +34,7 @@ typedef std::tuple<std::string, std::shared_ptr<DbgObject>>
 
 class DebuggerCallback;
 class IEvalCoordinator;
+class IDbgObjectFactory;
 class DbgClassProperty;
 struct MethodInfo;
 
@@ -45,6 +44,10 @@ struct MethodInfo;
 // method name, class name, file name and line number.
 class DbgStackFrame {
  public:
+  DbgStackFrame(std::shared_ptr<ICorDebugHelper> debug_helper,
+      std::shared_ptr<IDbgObjectFactory> obj_factory) :
+    debug_helper_(debug_helper), obj_factory_(obj_factory) {}
+
   // Populate method_name_, file_name_, line_number_ and breakpoint_id_.
   // Also populate local variables and method arguments into variables_
   // vectors.
@@ -207,6 +210,12 @@ class DbgStackFrame {
       std::vector<CComPtr<ICorDebugType>> *debug_types);
 
  private:
+  // Helper for ICorDebug method.
+  std::shared_ptr<ICorDebugHelper> debug_helper_;
+
+  // Factory to create DbgObject.
+  std::shared_ptr<IDbgObjectFactory> obj_factory_;
+   
   // Gets the metadata import of the module this frame is in.
   // We cannot store the IMetaDataImport directly because
   // they may be invalidated.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_string.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_string.cc
@@ -16,9 +16,9 @@
 
 #include <iostream>
 
+#include "class_names.h"
 #include "i_cor_debug_helper.h"
 #include "i_eval_coordinator.h"
-#include "class_names.h"
 
 using google::cloud::diagnostics::debug::Variable;
 using std::string;
@@ -32,8 +32,8 @@ void DbgString::Initialize(ICorDebugValue *debug_value, BOOL is_null) {
     return;
   }
 
-  initialize_hr_ =
-      CreateStrongHandle(debug_value, &object_handle_, GetErrorStream());
+  initialize_hr_ = debug_helper_->CreateStrongHandle(
+      debug_value, &object_handle_, GetErrorStream());
   if (FAILED(initialize_hr_)) {
     WriteError("Failed to create a handle for the string.");
   }
@@ -118,8 +118,8 @@ HRESULT DbgString::ExtractStringFromReference() {
     return hr;
   }
 
-  hr = ExtractStringFromICorDebugStringValue(debug_string,
-      &string_obj_, GetErrorStream());
+  hr = debug_helper_->ExtractStringFromICorDebugStringValue(
+      debug_string, &string_obj_, GetErrorStream());
   if (FAILED(hr)) {
     return hr;
   }

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_string.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_string.h
@@ -18,6 +18,7 @@
 #include "dbg_reference_object.h"
 
 namespace google_cloud_debugger {
+
 class EvalCoordinator;
 
 // This class represents .NET System.String.
@@ -25,7 +26,9 @@ class EvalCoordinator;
 // so we won't lose reference to it.
 class DbgString : public DbgReferenceObject {
  public:
-  DbgString(ICorDebugType *pType) : DbgReferenceObject(pType, 0) {}
+  DbgString(ICorDebugType *pType, std::shared_ptr<ICorDebugHelper> debug_helper)
+      : DbgReferenceObject(pType, 0, debug_helper,
+                           std::shared_ptr<IDbgObjectFactory>()) {}
 
   // Creates a strong handle to the object and stores it in string_handle_.
   void Initialize(ICorDebugValue *debug_value, BOOL is_null) override;
@@ -46,7 +49,7 @@ class DbgString : public DbgReferenceObject {
   // Dereferences the string handle and extracts out the string
   // into string_obj_. Will not do anything if string_obj_set_ is true.
   HRESULT ExtractStringFromReference();
-   
+
   // The underlying string object.
   std::string string_obj_;
 

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/debugger_callback.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/debugger_callback.h
@@ -266,6 +266,9 @@ class DebuggerCallback final : public ICorDebugManagedCallback,
   // manage breakpoints.
   std::unique_ptr<IBreakpointCollection> breakpoint_collection_;
 
+  // Helper methods for ICorDebug objects.
+  std::shared_ptr<ICorDebugHelper> debug_helper_;
+
   bool initialized_success_ = false;
 
   // The name of the pipe the debugger will use to communicate with the agent.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/i_eval_coordinator.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/i_eval_coordinator.h
@@ -29,6 +29,7 @@ namespace google_cloud_debugger {
 
 class IBreakpointCollection;
 class DbgBreakpoint;
+class IDbgObjectFactory;
 
 // An EvalCoordinator object is used by DebuggerCallback object to evaluate
 // and print out variables. It does so by creating a StackFrame on a new

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/i_portable_pdb_file.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/i_portable_pdb_file.h
@@ -26,6 +26,10 @@
 #include "document_index.h"
 #include "metadata_tables.h"
 
+namespace google_cloud_debugger {
+  class ICorDebugHelper;
+}
+
 namespace google_cloud_debugger_portable_pdb {
 
 struct StreamHeader;
@@ -48,7 +52,8 @@ class IPortablePdbFile {
   virtual ~IPortablePdbFile() = default;
 
   // Initializes the PDB, populates the name, metadata import and debug module.
-  virtual HRESULT Initialize(ICorDebugModule *debug_module) = 0;
+  virtual HRESULT Initialize(ICorDebugModule *debug_module,
+                             google_cloud_debugger::ICorDebugHelper *debug_helper) = 0;
 
   // Parses the pdb file. The name of the file will come from the
   // ICorDebugModule object that is used to initialize this object.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/method_info.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/method_info.h
@@ -24,6 +24,7 @@
 namespace google_cloud_debugger {
 
 class DbgStackFrame;
+class ICorDebugHelper;
 
 // Utility class that contains the properties
 // of a function needed to perform a method call.
@@ -52,7 +53,7 @@ struct MethodInfo {
   // is_static and has_generic_types field.
   HRESULT PopulateMethodDefFromNameAndArguments(
       IMetaDataImport *metadata_import, const mdTypeDef &class_token,
-      DbgStackFrame *stack_frame);
+      DbgStackFrame *stack_frame, ICorDebugHelper *debug_helper);
 
  private:
   // Helper function to find all methods that matches the name
@@ -69,7 +70,8 @@ struct MethodInfo {
   // and method_token if the method matched.
   HRESULT MatchMethodArgument(IMetaDataImport *metadata_import,
                               mdMethodDef method_def,
-                              DbgStackFrame *stack_frame);
+                              DbgStackFrame *stack_frame,
+                              ICorDebugHelper *debug_helper);
 };
 
 }  //  namespace google_cloud_debugger

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/portable_pdb_file.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/portable_pdb_file.cc
@@ -385,19 +385,20 @@ bool PortablePdbFile::ParseCompressedMetadataTableStream() {
   return true;
 }
 
-HRESULT PortablePdbFile::Initialize(ICorDebugModule *debug_module) {
+HRESULT PortablePdbFile::Initialize(ICorDebugModule *debug_module,
+    google_cloud_debugger::ICorDebugHelper *debug_helper) {
   if (!debug_module) {
     return E_INVALIDARG;
   }
 
-  HRESULT hr = google_cloud_debugger::GetMetadataImportFromICorDebugModule(
+  HRESULT hr = debug_helper->GetMetadataImportFromICorDebugModule(
       debug_module, &metadata_import_, &std::cerr);
   if (FAILED(hr)) {
     return hr;
   }
 
   vector<WCHAR> module_name;
-  hr = google_cloud_debugger::GetModuleNameFromICorDebugModule(debug_module,
+  hr = debug_helper->GetModuleNameFromICorDebugModule(debug_module,
                                                                &module_name,
                                                                &std::cerr);
   if (FAILED(hr)) {

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/portable_pdb_file.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/portable_pdb_file.h
@@ -42,7 +42,8 @@ class PortablePdbFile : public IPortablePdbFile {
   // Populates the name, metadata import and debug module.
   // This function will returns error if the name of the module
   // does not end with ".dll".
-  HRESULT Initialize(ICorDebugModule *debug_module);
+  HRESULT Initialize(ICorDebugModule *debug_module,
+                     google_cloud_debugger::ICorDebugHelper *debug_helper);
 
   // Parses the pdb file. The name of the file will come from the
   // ICorDebugModule object that is used to initialize this object.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/stack_frame_collection.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/stack_frame_collection.h
@@ -24,7 +24,8 @@ namespace google_cloud_debugger {
 
 class StackFrameCollection : public IStackFrameCollection {
  public:
-  StackFrameCollection(std::shared_ptr<ICorDebugHelper> debug_helper);
+  StackFrameCollection(std::shared_ptr<ICorDebugHelper> debug_helper,
+                       std::shared_ptr<IDbgObjectFactory> obj_factory);
 
   // This function first checks whether breakpoint has a condition.
   // If the condition evaluated to false, do nothing.
@@ -48,6 +49,9 @@ class StackFrameCollection : public IStackFrameCollection {
  private:
   // Class that contains helper method for ICorDebug objects.
   std::shared_ptr<ICorDebugHelper> debug_helper_;
+
+  // Factory for creating DbgObject.
+  std::shared_ptr<IDbgObjectFactory> obj_factory_;
 
   // Given a PDB file, this function tries to find the metadata of the function
   // with token target_function_token in the PDB file. If found, this function


### PR DESCRIPTION
Refactor out the code to use the `IDbgObjectFactory` and `ICorDebugHelper` introduced in the previous PRs.