### PR TITLE
Ensure the debugger shuts down when the agent shuts down.

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Agent.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Agent.cs
@@ -77,7 +77,7 @@ namespace Google.Cloud.Diagnostics.Debug
         /// <inheritdoc />
         public void Dispose()
         {
-            _process?.Dispose();
+            _process?.Kill();
             _cts.Cancel();
         }
 


### PR DESCRIPTION
Also ensure the agent and debugger shut down in the tests.

Process.Dispose() does not ensure the porcess will be shutdown while Porcess.Kill() does.  Kill is more forceful but given that we are ended the agent/debugger processes this should be okay.

Fixes #146