### PR TITLE
If the process the debugger is watching stops shut down the debugger.

### DIFF
--- a/src/google_cloud_debugger/google_cloud_debugger_lib/breakpoint_collection.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/breakpoint_collection.cc
@@ -235,11 +235,21 @@ HRESULT BreakpointCollection::SyncBreakpoints() {
 }
 
 HRESULT BreakpointCollection::CancelSyncBreakpoints() {
+  HRESULT hr = S_OK;
+
   if (breakpoint_client_read_) {
-    return breakpoint_client_read_->ShutDown();
+	hr = breakpoint_client_read_->ShutDown();
+  }
+  
+  if (FAILED(hr)) {
+	return hr;
   }
 
-  return S_OK;
+  if (breakpoint_client_write_) {
+	hr = breakpoint_client_write_->ShutDown();
+  }
+
+  return hr;
 }
 
 HRESULT BreakpointCollection::ActivateBreakpointHelper(

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/debugger_callback.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/debugger_callback.cc
@@ -108,6 +108,10 @@ ULONG STDMETHODCALLTYPE DebuggerCallback::Release(void) {
   return count;
 }
 
+HRESULT STDMETHODCALLTYPE DebuggerCallback::ExitProcess(ICorDebugProcess *process) {
+	return breakpoint_collection_->CancelSyncBreakpoints();
+}
+
 HRESULT STDMETHODCALLTYPE DebuggerCallback::Breakpoint(
     ICorDebugAppDomain *appdomain, ICorDebugThread *debug_thread,
     ICorDebugBreakpoint *debug_breakpoint) {

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/debugger_callback.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/debugger_callback.h
@@ -67,6 +67,9 @@ class DebuggerCallback final : public ICorDebugManagedCallback,
   HRESULT STDMETHODCALLTYPE LoadModule(ICorDebugAppDomain *appdomain,
                                        ICorDebugModule *debug_module) override;
 
+  // This method is called when the process the debugger is watching exits.
+  HRESULT STDMETHODCALLTYPE ExitProcess(ICorDebugProcess *process) override;
+
 // This macro creates a callback function stub to override methods in
 // ICorDebugManagedCallback and ICorDebugManagedCallback2 interfaces
 // that we are not interested in processing.
@@ -89,7 +92,6 @@ class DebuggerCallback final : public ICorDebugManagedCallback,
   DEBUGGERCALLBACK_STUB(StepComplete, ICorDebugAppDomain,
                         ICorDebugThread *debug_thread,
                         ICorDebugStepper *stepper, CorDebugStepReason reason);
-  DEBUGGERCALLBACK_STUB(ExitProcess, ICorDebugProcess);
   DEBUGGERCALLBACK_STUB(CreateThread, ICorDebugAppDomain,
                         ICorDebugThread *debug_thread);
   DEBUGGERCALLBACK_STUB(ExitThread, ICorDebugAppDomain,


### PR DESCRIPTION
This is done by shutting down the pipe between the debugger and agent.  This will cause the sync loop to fail and exit the program.  This will also then cause the agent to exit when it has no debugger to talk too.

Fixes #265