### PR TITLE
Update the Debugger Ref and removed old unneeded refs

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/Google.Cloud.Diagnostics.Debug.IntegrationTests.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/Google.Cloud.Diagnostics.Debug.IntegrationTests.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
-    <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta02" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.csproj
@@ -15,9 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="Google.Api.Gax" Version="2.2.1" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.32.2" />
-    <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta01" />
+    <PackageReference Include="Google.Cloud.Debugger.V2" Version="1.0.0-beta02" />
     <PackageReference Include="Google.Cloud.DevTools.Common" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.5.1" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />


### PR DESCRIPTION
These old refs were needed to ping to working versions after a bug fix.  The Debugger ref now has the right versions

Fixes #220