### PR TITLE
Add support for async method

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTests.cs
@@ -127,6 +127,79 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
         }
 
         [Fact]
+        public async Task BreakpointHit_Async()
+        {
+            using (var app = StartTestApp(debugEnabled: true))
+            {
+                var debuggee = Polling.GetDebuggee(app.Module, app.Version);
+                var breakpoint = SetBreakpointAndSleep(debuggee.Id, TestApplication.MainClass, TestApplication.AsyncBottomLine);
+
+                string testMessage = "testmessage";
+
+                using (HttpClient client = new HttpClient())
+                {
+                    await client.GetAsync($"{app.AppUrlAsync}/{testMessage}");
+                }
+
+                var newBp = Polling.GetBreakpoint(debuggee.Id, breakpoint.Id);
+
+                // Check basic breakpoint values.
+                Assert.True(newBp.IsFinalState);
+                Assert.Equal(DebuggerBreakpoint.Types.Action.Capture, newBp.Action);
+                Assert.Equal(breakpoint.CreateTime, newBp.CreateTime);
+                Assert.Empty(newBp.Expressions);
+                Assert.Empty(newBp.Condition);
+                Assert.True(newBp.FinalTime.ToDateTime() > newBp.CreateTime.ToDateTime());
+
+                // Only check the first one as it's the only one with information we care about. 
+                var stackframe = newBp.StackFrames[0];
+
+                // Check the function is async.
+                //Assert.Contains($"{typeof(TestApp.MainController).ToString()}.Async", stackframe.Function);
+
+                // Check the location is accurate.
+                var location = stackframe.Location;
+                Assert.Equal(TestApplication.AsyncBottomLine, location.Line);
+                Assert.Contains("src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.TestApp/MainController.cs", location.Path);
+
+                // Two arguments, the param 'message' and 'this'.
+                var arguments = stackframe.Arguments;
+                Assert.Equal(2, arguments.Count);
+
+                // Check 'this' arg for the class values.
+                var thisArg = arguments.Where(l => l.Name == "this").Single();
+                Assert.Equal(typeof(TestApp.MainController).ToString(), thisArg.Type);
+                Assert.Equal(2, thisArg.Members.Count);
+
+                var privateStaticString = thisArg.Members.Where(m => m.Name == "_privateReadOnlyString").Single();
+                Assert.Equal(typeof(System.String).ToString(), privateStaticString.Type);
+
+                var publicString = thisArg.Members.Where(m => m.Name == "PublicString").Single();
+                Assert.Equal(typeof(System.String).ToString(), publicString.Type);
+                Assert.Equal(new TestApp.MainController().PublicString, publicString.Value);
+
+                // Check 'message' arg.
+                var messageArg = arguments.Where(l => l.Name == "message").Single();
+                Assert.Equal(typeof(System.String).ToString(), messageArg.Type);
+                Assert.Equal(testMessage, messageArg.Value);
+
+                // There should be 2 local variables.
+                var locals = stackframe.Locals;
+                Assert.Equal(2, locals.Count);
+
+                // One of the variable should be testInt.
+                var testIntLocal = locals.Where(m => m.Name == "testInt").Single();
+                Assert.Equal(typeof(System.Int32).ToString(), testIntLocal.Type);
+                Assert.Equal("0", testIntLocal.Value.ToString());
+
+                // One of the local variables will be testString with the same value as testMessage.
+                var testStringLocal = locals.Where(m => m.Name == "testString").Single();
+                Assert.Equal(typeof(System.String).ToString(), testStringLocal.Type);
+                Assert.Equal(testMessage, testStringLocal.Value);
+            }
+        }
+
+        [Fact]
         public async Task BreakpointHit_Condition()
         {
             int targetIValue = 10;

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTests.cs
@@ -155,7 +155,9 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
                 var stackframe = newBp.StackFrames[0];
 
                 // Check the function is async.
-                //Assert.Contains($"{typeof(TestApp.MainController).ToString()}.Async", stackframe.Function);
+                // TODO(quoct): Currently, the function name is the name of the state machine
+                // so this condition will be false. We have to fix this in the debugger side.
+                // Assert.Contains($"{typeof(TestApp.MainController).ToString()}.Async", stackframe.Function);
 
                 // Check the location is accurate.
                 var location = stackframe.Location;

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/TestApplication.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/TestApplication.cs
@@ -27,11 +27,12 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
     public class TestApplication : IDisposable
     {
         public static readonly string MainClass = "MainController.cs";
-        public static readonly int HelloLine = 33;
-        public static readonly int EchoTopLine = 38;
-        public static readonly int EchoBottomLine = 49;
-        public static readonly int PidLine = 59;
-        public static readonly int LoopMiddle = 67;
+        public static readonly int HelloLine = 34;
+        public static readonly int EchoTopLine = 39;
+        public static readonly int EchoBottomLine = 50;
+        public static readonly int PidLine = 60;
+        public static readonly int LoopMiddle = 68;
+        public static readonly int AsyncBottomLine = 77;
 
         /// <summary>Get the echo url with 'i' appended.</summary>
         public static string GetEchoUrl(TestApplication app, int i) => $"{app.AppUrlEcho}/{i}";
@@ -53,6 +54,9 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
 
         /// <summary>The url to the middle of the loop from the test application.</summary>
         public string AppUrlLoop => $"{AppUrlBase}/Main/Loop";
+
+        /// <summary>The url to the async method for the test application.</summary>
+        public string AppUrlAsync => $"{AppUrlBase}/Main/Async";
 
         /// <summary>The module of the a debuggee.</summary>
         public readonly string Module = nameof(DebuggerTestBase);

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.TestApp/MainController.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.TestApp/MainController.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Diagnostics.Debug.TestApp
 {
@@ -67,6 +68,12 @@ namespace Google.Cloud.Diagnostics.Debug.TestApp
                 t = i;
             }
             return t;
+        }
+
+        public async Task Async(string message)
+        {
+            int testInt = 0;
+            string testString = message;
         }
     }
 }

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/cor_debug_helper.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/cor_debug_helper.cc
@@ -144,43 +144,15 @@ HRESULT CorDebugHelper::GetICorDebugType(ICorDebugValue *debug_value,
   return hr;
 }
 
-HRESULT CorDebugHelper::GetClassTokenFromDebugType(
-    ICorDebugType *debug_type,
-    mdTypeDef *class_token,
-    std::ostream *err_stream) {
-  CComPtr<ICorDebugClass> debug_class;
-  HRESULT hr = debug_type->GetClass(&debug_class);
-  if (FAILED(hr)) {
-    *err_stream << "Cannot get ICorDebugClass.";
-    return hr;
-  }
-
-  return debug_class->GetToken(class_token);
-}
-
 HRESULT CorDebugHelper::CheckAsyncStateObj(
-    ICorDebugValue *async_state_obj,
+    mdTypeDef class_token,
     IMetaDataImport *metadata_import) {
-  CComPtr<ICorDebugType> debug_type;
-  HRESULT hr = GetICorDebugType(async_state_obj, &debug_type, &cerr);
-  if (FAILED(hr)) {
-    cerr << "Failed to get ICorDebugType.";
-    return hr;
-  }
-
-  mdTypeDef class_token;
-  hr = GetClassTokenFromDebugType(debug_type, &class_token, &cerr);
-  if (FAILED(hr)) {
-    cerr << "Failed to get class token.";
-    return hr;
-  }
-
   // If this is a state machine, it will have a field <>1__state.
   const static std::string state_field_name = "<>1__state";
   mdFieldDef field_def;
   std::vector<WCHAR> wchar_state_field_name = ConvertStringToWCharPtr(state_field_name);
-  hr = metadata_import->FindField(class_token, wchar_state_field_name.data(),
-                                  nullptr, 0, &field_def);
+  HRESULT hr = metadata_import->FindField(class_token, wchar_state_field_name.data(),
+                                          nullptr, 0, &field_def);
   if (FAILED(hr)) {
     return S_FALSE;
   }

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/cor_debug_helper.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/cor_debug_helper.h
@@ -50,6 +50,16 @@ class CorDebugHelper : public ICorDebugHelper {
                                    ICorDebugType **debug_type,
                                    std::ostream *err_stream) override;
 
+  // Gets class token from an ICorDebugType.
+  virtual HRESULT GetClassTokenFromDebugType(
+      ICorDebugType *debug_type, mdTypeDef *class_token,
+      std::ostream *err_stream) override;
+
+  // Returns S_OK if async_state_obj is an async state machine object.
+  // Returns S_FALSE otherwise.
+  virtual HRESULT CheckAsyncStateObj(ICorDebugValue *async_state_obj,
+                                     IMetaDataImport *metadata_import) override;
+
   // Given an ICorDebugValue, keep trying to dereference it until we cannot
   // anymore. This function will set is_null to true if this is a null
   // reference. If debug_value is not a reference, this function will simply set

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/cor_debug_helper.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/cor_debug_helper.h
@@ -50,14 +50,9 @@ class CorDebugHelper : public ICorDebugHelper {
                                    ICorDebugType **debug_type,
                                    std::ostream *err_stream) override;
 
-  // Gets class token from an ICorDebugType.
-  virtual HRESULT GetClassTokenFromDebugType(
-      ICorDebugType *debug_type, mdTypeDef *class_token,
-      std::ostream *err_stream) override;
-
-  // Returns S_OK if async_state_obj is an async state machine object.
-  // Returns S_FALSE otherwise.
-  virtual HRESULT CheckAsyncStateObj(ICorDebugValue *async_state_obj,
+  // Returns S_OK if class represented by class_token is an async
+  // state machine class. Returns S_FALSE otherwise.
+  virtual HRESULT CheckAsyncStateObj(mdTypeDef class_token,
                                      IMetaDataImport *metadata_import) override;
 
   // Given an ICorDebugValue, keep trying to dereference it until we cannot

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_class.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_class.h
@@ -62,6 +62,11 @@ class DbgClass : public DbgReferenceObject {
   // Populates type_string with type of this class.
   HRESULT GetTypeString(std::string *type_string) override;
 
+  // Returns the field of this class.
+  const std::vector<std::shared_ptr<IDbgClassMember>> &GetFields() {
+    return class_fields_;
+  }
+
   // Search class_fields_ vector for a field with name field_name and
   // stores the pointer to the value of that field in field_value.
   // If class_fields_ are not populated, then this will call the
@@ -72,6 +77,10 @@ class DbgClass : public DbgReferenceObject {
   // Returns an ICorDebugType vector that represents the generic
   // types of the class.
   HRESULT GetGenericTypes(std::vector<CComPtr<ICorDebugType>> *debug_types);
+
+  // Processes members of this class, creating DbgObject
+  // for each of them.
+  HRESULT ProcessClassMembers();
 
   // Helper method to process the members of this class.
   // If not overriden, this method will process this object as if
@@ -172,10 +181,6 @@ class DbgClass : public DbgReferenceObject {
 
   // Processes the class properties and stores the fields in class_fields_.
   HRESULT ProcessProperties(IMetaDataImport *metadata_import);
-
-  // Processes members of this class, creating DbgObject
-  // for each of them.
-  HRESULT ProcessClassMembers();
 
   // Given a field name, creates a DbgObject that represents the value
   // of the field in this object.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.cc
@@ -21,6 +21,7 @@
 #include "compiler_helpers.h"
 #include "constants.h"
 #include "dbg_breakpoint.h"
+#include "dbg_class.h"
 #include "dbg_class_property.h"
 #include "dbg_reference_object.h"
 #include "debugger_callback.h"
@@ -93,21 +94,7 @@ HRESULT DbgStackFrame::Initialize(
 
   is_static_method_ = IsMdStatic(method_flag);
 
-  CComPtr<ICorDebugValueEnum> local_enum;
   CComPtr<ICorDebugValueEnum> method_arg_enum;
-
-  hr = il_frame->EnumerateLocalVariables(&local_enum);
-  if (FAILED(hr)) {
-    cerr << "Failed to get local variable.";
-    return hr;
-  }
-
-  // The populate methods will write errors.
-  hr = ProcessLocalVariables(local_enum, variable_infos);
-  if (FAILED(hr)) {
-    return hr;
-  }
-
   // Even if we are not in a method (no arguments), this will return S_OK.
   hr = il_frame->EnumerateArguments(&method_arg_enum);
   if (FAILED(hr)) {
@@ -123,6 +110,15 @@ HRESULT DbgStackFrame::Initialize(
   hr = InitializeClassGenericTypeParameters(metadata_import, il_frame);
   if (FAILED(hr)) {
     return hr;
+  }
+
+  if (!is_async_method_) {
+    CComPtr<ICorDebugValueEnum> local_enum;
+    // The populate methods will write errors.
+    hr = ProcessLocalVariables(local_enum, variable_infos);
+    if (FAILED(hr)) {
+      return hr;
+    }
   }
 
   is_processed_il_frame_ = true;
@@ -220,6 +216,14 @@ HRESULT DbgStackFrame::ProcessMethodArguments(
   // Add "this" if method is not static.
   if (!is_static_method_) {
     method_argument_names.push_back("this");
+
+    // If we are in an async method, ProcessAsyncMethod will populate
+    // local variables and method arguments for us. Otherwise, S_FALSE
+    // wlil be returned and we proceed to process method arguments as normal.
+    hr = ProcessAsyncMethod(method_arg_values[0], metadata_import);
+    if (hr != S_FALSE) {
+      return hr;
+    }
   }
 
   vector<mdParamDef> method_args(100, 0);
@@ -283,6 +287,81 @@ HRESULT DbgStackFrame::ProcessMethodArguments(
   }
 
   return S_OK;
+}
+
+HRESULT DbgStackFrame::ProcessAsyncMethod(
+    ICorDebugValue *async_state_obj, IMetaDataImport *metadata_import) {
+  CComPtr<ICorDebugType> debug_type;
+  HRESULT hr = debug_helper_->CheckAsyncStateObj(async_state_obj, metadata_import);
+  if (FAILED(hr)) {
+    cerr << "Failed to check whether method is async or not.";
+    return hr;
+  }
+
+  if (hr == S_FALSE) {
+    return hr;
+  }
+
+  // We are inside an async method. We create a DbgObject that represents
+  // the state machine. Within this object, there are fields that represent
+  // local variable and method arguments. We will populate
+  // variables_ and method_arguments_ with these fields.
+  is_async_method_ = true;
+  std::unique_ptr<DbgObject> state_machine_obj;
+  hr = obj_factory_->CreateDbgObject(async_state_obj, object_depth_ + 1,
+    &state_machine_obj, &std::cerr);
+  if (FAILED(hr)) {
+    cerr << "Failed to create state machine object for async method.";
+    return hr;
+  }
+
+  DbgClass *class_obj = dynamic_cast<DbgClass *>(state_machine_obj.get());
+  if (!class_obj) {
+    cerr << "Failed to retrieve state machine object class.";
+    return hr;
+  }
+
+  hr = class_obj->ProcessClassMembers();
+  if (FAILED(hr)) {
+    cerr << "Failed to process async state machine members.";
+    return hr;
+  }
+
+  ProcessAsyncVariablesAndMethodArgs(class_obj->GetFields());
+  return S_OK;
+}
+
+void DbgStackFrame::ProcessAsyncVariablesAndMethodArgs(
+    const std::vector<std::shared_ptr<IDbgClassMember>> &async_fields){
+  // This is the name of the field that represents "this" object.
+  static const std::string async_this = "<>4__this";
+
+  // Variable will be stored as field <name>5__1, <name>5__2, etc.
+  static const std::string async_variable_name = ">5__";
+
+  for (auto &class_field : async_fields) {
+    std::string field_name = class_field->GetMemberName();
+    if (field_name[0] != '<') {
+      method_arguments_.push_back(std::make_tuple(
+        class_field->GetMemberName(), class_field->GetMemberValue()));
+      continue;
+    }
+
+    if (field_name.compare(async_this) == 0) {
+      method_arguments_.push_back(std::make_tuple(
+        "this", class_field->GetMemberValue()));
+      is_static_method_ = false;
+      continue;
+    }
+
+    size_t end_bracket_position = field_name.find(async_variable_name);
+    // Extracts out the field name.
+    if (end_bracket_position != string::npos) {
+      std::string variable_name = field_name.substr(1, end_bracket_position - 1);
+      variables_.push_back(std::make_tuple(
+        variable_name, class_field->GetMemberValue()));
+    }
+  }
 }
 
 HRESULT DbgStackFrame::GetDebugFunctionFromClass(

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.cc
@@ -299,7 +299,7 @@ HRESULT DbgStackFrame::ProcessAsyncMethod(ICorDebugValue *async_state_obj,
                                           IMetaDataImport *metadata_import) {
   CComPtr<ICorDebugType> debug_type;
   HRESULT hr =
-      debug_helper_->CheckAsyncStateObj(async_state_obj, metadata_import);
+      debug_helper_->CheckAsyncStateObj(class_token_, metadata_import);
   if (FAILED(hr)) {
     cerr << "Failed to check whether method is async or not.";
     return hr;

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/i_cor_debug_helper.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/i_cor_debug_helper.h
@@ -57,14 +57,9 @@ class ICorDebugHelper {
                                    ICorDebugType **debug_type,
                                    std::ostream *err_stream) = 0;
 
-  // Gets class token from an ICorDebugType.
-  virtual HRESULT GetClassTokenFromDebugType(
-      ICorDebugType *debug_type, mdTypeDef *class_token,
-      std::ostream *err_stream) = 0;
-
-  // Returns S_OK if async_state_obj is an async state machine object.
-  // Returns S_FALSE otherwise.
-  virtual HRESULT CheckAsyncStateObj(ICorDebugValue *async_state_obj,
+  // Returns S_OK if class represented by class_token is an async
+  // state machine class. Returns S_FALSE otherwise.
+  virtual HRESULT CheckAsyncStateObj(mdTypeDef class_token,
                                      IMetaDataImport *metadata_import) = 0;
 
   // Given an ICorDebugValue, keep trying to dereference it until we cannot

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/i_cor_debug_helper.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/i_cor_debug_helper.h
@@ -57,6 +57,16 @@ class ICorDebugHelper {
                                    ICorDebugType **debug_type,
                                    std::ostream *err_stream) = 0;
 
+  // Gets class token from an ICorDebugType.
+  virtual HRESULT GetClassTokenFromDebugType(
+      ICorDebugType *debug_type, mdTypeDef *class_token,
+      std::ostream *err_stream) = 0;
+
+  // Returns S_OK if async_state_obj is an async state machine object.
+  // Returns S_FALSE otherwise.
+  virtual HRESULT CheckAsyncStateObj(ICorDebugValue *async_state_obj,
+                                     IMetaDataImport *metadata_import) = 0;
+
   // Given an ICorDebugValue, keep trying to dereference it until we cannot
   // anymore. This function will set is_null to true if this is a null
   // reference. If debug_value is not a reference, this function will simply set


### PR DESCRIPTION
This is done by checking whether the method we are in is an async state machine. If so, then some fields of the state machine will represent local variables and method arguments and we can use those fields to populate the breakpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-dotnet-debugger/338)
<!-- Reviewable:end -->
