### PR TITLE
Update build-deps.cmd to automatically grab the root and only take a config param.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ configuration: Debug
 # Build dependencies and code
 build_script:
   - git submodule update --init --recursive
-  - build-deps.cmd %APPVEYOR_BUILD_FOLDER%\ %CONFIGURATION% %PLATFORM%
+  - build-deps.cmd %CONFIGURATION%
   - build.cmd %CONFIGURATION%
 
 test_script:

--- a/build-deps.cmd
+++ b/build-deps.cmd
@@ -3,25 +3,22 @@
 
 :: TODO(talarico): Allow building with multiple Visual Studio versions. 
 
-:: Check that the user passed in a valid parameter.
-if "%3" == "" (
-  echo "Parameters should be: repository root, configuration, platform"
-  exit /B
-)
+:: The only optional parameter is the configuration which defaults to Debug.
 
-SET ROOT_DIR=%1
-SET CONFIG=%2
-SET PLATFORM=%3
-SET PLATFORM_STR=""
 
-SET THIRD_PARTY_DIR=%ROOT_DIR%third_party
+SET ROOT_DIR=%~dp0
+SET CONFIG=%1
+SET PLATFORM=x64
+SET PLATFORM_STR= Win64
+
+SET THIRD_PARTY_DIR=%ROOT_DIR%\third_party
 SET PROTOBUF_DIR=%THIRD_PARTY_DIR%\protobuf
 SET GMOCK_DIR=%THIRD_PARTY_DIR%\googletest\googlemock
 SET GTEST_DIR=%THIRD_PARTY_DIR%\googletest\googletest
 SET CORECLR_DIR=%THIRD_PARTY_DIR%\coreclr
 
-if "%3" == "x64" (
-  SET PLATFORM_STR= Win64
+if "%1" == "" (
+  SET CONFIG=Debug
 )
 
 :: Ensure the submodule are up to date.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/google_cloud_debugger_lib.vcxproj
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/google_cloud_debugger_lib.vcxproj
@@ -124,7 +124,7 @@
       <AdditionalDependencies>libprotobuf.lib;corguids.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
     <PreBuildEvent>
-      <Command>$(SolutionDir)..\..\build-deps.cmd $(SolutionDir)..\..\ $(Configuration) $(Platform)</Command>
+      <Command>$(SolutionDir)..\..\build-deps.cmd $(Configuration)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>Copy /Y "$(SolutionDir)..\..\third_party\coreclr\bin\obj\Windows_NT.$(Platform).$(Configuration)\src\dlls\dbgshim\$(Configuration)" "$(TargetDir)"</Command>


### PR DESCRIPTION
We only support x64 so we have no need for the platform option.