### PR TITLE
Remove files during AppVeyor builds to help free up space.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,10 @@ image: Visual Studio 2017
 # Pull down all submodule code
 init:
   - git config --global core.autocrlf input
+  # This change was recommended by the AppVeyor team to save space.
+  - rmdir C:\cygwin /s /q
+  - rmdir C:\QT /s /q
+
 
 # Cache the third party code as it can take 20+ min to build
 cache:


### PR DESCRIPTION
This was recommended by the AppVeyor team as we hit an internal limit that caused an automated system to ban our account.