### PR TITLE
Increase the tolerance of checks in the BreakpointActionServerTest.

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointActionServerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointActionServerTests.cs
@@ -57,7 +57,7 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             var waitTime = TimeSpan.FromMilliseconds(10);
             var elapsedMilliseconds = RunLoop(TimeSpan.FromSeconds(1), waitTime);
             var estimatedCalls = elapsedMilliseconds / waitTime.TotalMilliseconds;
-            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2 , estimatedCalls * 2);
+            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2 , estimatedCalls + estimatedCalls / 2);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             // call time is 140.  (300 - 140)/100 = 1.6 =~ 2
             // Call wait times (20, 40, 80, 100, 100, 100...)
             var estimatedCalls = (elapsedMilliseconds / _maxBackOffWaitTime.TotalMilliseconds) - 2;
-            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2, estimatedCalls * 2);
+            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2, estimatedCalls + estimatedCalls / 2);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             // call time is 240.  (240 - (4 * 10)) / 10 = 20;
             // Call wait times (20, 40, 80, 100, 10, 10...)
             var estimatedCalls = (elapsedMilliseconds / waitTime.TotalMilliseconds) - 20;
-            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2, estimatedCalls * 2);
+            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2, estimatedCalls + estimatedCalls / 2);
         }
 
         /// <summary>

--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointActionServerTests.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.Tests/BreakpointActionServerTests.cs
@@ -24,8 +24,6 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
 {
     public class BreakpointActionServerTests
     {
-        // The tolerance for number of calls to the main action.
-        private static readonly int _tolerance = 20;
         private static readonly TimeSpan _minBackOffWaitTime = TimeSpan.FromMilliseconds(10);
         private static readonly TimeSpan _maxBackOffWaitTime = TimeSpan.FromMilliseconds(100);
 
@@ -59,7 +57,7 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             var waitTime = TimeSpan.FromMilliseconds(10);
             var elapsedMilliseconds = RunLoop(TimeSpan.FromSeconds(1), waitTime);
             var estimatedCalls = elapsedMilliseconds / waitTime.TotalMilliseconds;
-            Assert.InRange(_fakeActionServer.Counter, estimatedCalls - _tolerance, estimatedCalls + _tolerance);
+            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2 , estimatedCalls * 2);
         }
 
         [Fact]
@@ -73,7 +71,7 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             // call time is 140.  (300 - 140)/100 = 1.6 =~ 2
             // Call wait times (20, 40, 80, 100, 100, 100...)
             var estimatedCalls = (elapsedMilliseconds / _maxBackOffWaitTime.TotalMilliseconds) - 2;
-            Assert.InRange(_fakeActionServer.Counter, estimatedCalls - _tolerance, estimatedCalls + _tolerance);
+            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2, estimatedCalls * 2);
         }
 
         [Fact]
@@ -87,7 +85,7 @@ namespace Google.Cloud.Diagnostics.Debug.Tests
             // call time is 240.  (240 - (4 * 10)) / 10 = 20;
             // Call wait times (20, 40, 80, 100, 10, 10...)
             var estimatedCalls = (elapsedMilliseconds / waitTime.TotalMilliseconds) - 20;
-            Assert.InRange(_fakeActionServer.Counter, estimatedCalls - _tolerance, estimatedCalls + _tolerance);
+            Assert.InRange(_fakeActionServer.Counter, estimatedCalls / 2, estimatedCalls * 2);
         }
 
         /// <summary>


### PR DESCRIPTION
After looking at the issue more and doing some research on Thread.Sleep's behavior is relatively unreliable and subject to the underlying operating system and other threads.