### PR TITLE
Give the test app more time to spin up during integration tests.

### DIFF
--- a/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTestBase.cs
+++ b/src/Google.Cloud.Diagnostics.Debug/Google.Cloud.Diagnostics.Debug.IntegrationTests/DebuggerTestBase.cs
@@ -94,8 +94,10 @@ namespace Google.Cloud.Diagnostics.Debug.IntegrationTests
                 using (HttpClient client = new HttpClient())
                 {
                     // Allow the app a chance to start up as it may not start
-                    // right away.
-                    int attempts = 10;
+                    // right away.  This generally takes less than 5 seconds
+                    // but we give more time as sometimes it can take longer
+                    // and is outside our control in most cases.
+                    int attempts = 30;
                     for (int i = 0; i < attempts; i++)
                     {
                         try


### PR DESCRIPTION
This generally starts in under 5 seconds but can sometimes take longer and isn't in our control and depends on multiple external factors.

We were seeing random failures on the linux CI due to this.