### PR TITLE
Use unordered_map instead of map

### DIFF
--- a/src/google_cloud_debugger/google_cloud_debugger_lib/breakpoint_collection.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/breakpoint_collection.h
@@ -15,7 +15,7 @@
 #ifndef BREAKPOINT_COLLECTION_H_
 #define BREAKPOINT_COLLECTION_H_
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -94,7 +94,7 @@ class BreakpointCollection : public IBreakpointCollection {
   // std::vector<std::shared_ptr<DbgBreakpoint>> breakpoints_;
 
   // A map of location to a collection of breakpoint at that location.
-  std::map<std::string, std::unique_ptr<BreakpointLocationCollection>>
+  std::unordered_map<std::string, std::unique_ptr<BreakpointLocationCollection>>
     location_to_breakpoints_;
 
   // Activate a breakpoint in a portable pdb file.

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/compiler_helpers.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/compiler_helpers.cc
@@ -311,9 +311,15 @@ CorElementType TypeCompilerHelper::ConvertStringToCorElementType(
   }
 }
 
+struct CorElementTypeHash {
+  std::size_t operator()(CorElementType cor_type) const {
+    return static_cast<std::size_t>(cor_type);
+  }
+};
+
 HRESULT TypeCompilerHelper::ConvertCorElementTypeToString(
     const CorElementType &cor_type, std::string *result) {
-  static std::unordered_map<CorElementType, std::string> cor_type_to_string{
+  static std::unordered_map<CorElementType, std::string, CorElementTypeHash> cor_type_to_string{
       {CorElementType::ELEMENT_TYPE_BOOLEAN, kBooleanClassName},
       {CorElementType::ELEMENT_TYPE_I1, kSByteClassName},
       {CorElementType::ELEMENT_TYPE_CHAR, kCharClassName},

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/compiler_helpers.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/compiler_helpers.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <map>
+#include <unordered_map>
 
 #include "class_names.h"
 #include "compiler_helpers.h"
@@ -271,7 +271,7 @@ bool TypeCompilerHelper::IsObjectType(const CorElementType &cor_type) {
 
 CorElementType TypeCompilerHelper::ConvertStringToCorElementType(
     const std::string &type_string) {
-  static std::map<std::string, CorElementType> string_to_cor_type{
+  static std::unordered_map<std::string, CorElementType> string_to_cor_type{
       {kCharClassName, CorElementType::ELEMENT_TYPE_BOOLEAN},
       {kSByteClassName, CorElementType::ELEMENT_TYPE_I1},
       {kCharClassName, CorElementType::ELEMENT_TYPE_CHAR},
@@ -313,7 +313,7 @@ CorElementType TypeCompilerHelper::ConvertStringToCorElementType(
 
 HRESULT TypeCompilerHelper::ConvertCorElementTypeToString(
     const CorElementType &cor_type, std::string *result) {
-  static std::map<CorElementType, std::string> cor_type_to_string{
+  static std::unordered_map<CorElementType, std::string> cor_type_to_string{
       {CorElementType::ELEMENT_TYPE_BOOLEAN, kBooleanClassName},
       {CorElementType::ELEMENT_TYPE_I1, kSByteClassName},
       {CorElementType::ELEMENT_TYPE_CHAR, kCharClassName},

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_class.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_class.cc
@@ -38,7 +38,9 @@ using std::vector;
 
 namespace google_cloud_debugger {
 
-std::map<std::string, std::map<std::string, std::shared_ptr<IDbgClassMember>>>
+std::unordered_map<
+    std::string,
+    std::unordered_map<std::string, std::shared_ptr<IDbgClassMember>>>
     DbgClass::static_class_members_;
 
 HRESULT DbgClass::GetNonStaticField(const std::string &field_name,
@@ -463,7 +465,7 @@ void DbgClass::StoreStaticClassMember(const string &module_name,
   string key = GetStaticCacheKey(module_name, class_name);
   if (static_class_members_.find(key) == static_class_members_.end()) {
     static_class_members_[key] =
-        std::map<string, shared_ptr<IDbgClassMember>>();
+        std::unordered_map<string, shared_ptr<IDbgClassMember>>();
   }
 
   static_class_members_[key][member_name] = object;

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_class.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_class.h
@@ -15,8 +15,8 @@
 #ifndef DBG_CLASS_H_
 #define DBG_CLASS_H_
 
-#include <map>
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -108,13 +108,19 @@ class DbgClass : public DbgReferenceObject {
   static void ClearStaticCache() { static_class_members_.clear(); }
 
   // Sets the name of the module this class is in.
-  void SetModuleName(const std::string &module_name) { module_name_ = module_name; };
+  void SetModuleName(const std::string &module_name) {
+    module_name_ = module_name;
+  };
 
   // Sets the name of this class.
-  void SetClassName(const std::string &class_name) { class_name_ = class_name; };
+  void SetClassName(const std::string &class_name) {
+    class_name_ = class_name;
+  };
 
   // Sets the class token.
-  void SetClassToken(const mdTypeDef &class_token) { class_token_ = class_token; };
+  void SetClassToken(const mdTypeDef &class_token) {
+    class_token_ = class_token;
+  };
 
   // Gets the class token.
   mdTypeDef GetClassToken() { return class_token_; }
@@ -240,8 +246,9 @@ class DbgClass : public DbgReferenceObject {
   // Cache of static class members.
   // First key is the module name and class name.
   // Second key is the member name.
-  static std::map<std::string,
-                  std::map<std::string, std::shared_ptr<IDbgClassMember>>>
+  static std::unordered_map<
+      std::string,
+      std::unordered_map<std::string, std::shared_ptr<IDbgClassMember>>>
       static_class_members_;
 };
 

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.cc
@@ -27,7 +27,8 @@ using std::vector;
 namespace google_cloud_debugger {
 
 const string DbgEnum::kEnumValue = "value__";
-std::map<std::string, std::vector<std::tuple<UVCP_CONSTANT, std::string>>>
+std::unordered_map<std::string,
+                   std::vector<std::tuple<UVCP_CONSTANT, std::string>>>
     DbgEnum::enum_values_dict;
 
 HRESULT DbgEnum::PopulateValue(Variable *variable) {

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.h
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_enum.h
@@ -15,9 +15,9 @@
 #ifndef DBG_ENUM_H_
 #define DBG_ENUM_H_
 
-#include <map>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "dbg_class.h"
@@ -85,8 +85,8 @@ class DbgEnum : public DbgClass {
   // Values are the list of possible values of that enum.
   // For example, enum Week { Monday, Tuesday } will have key
   // as Week and values as (0, "Monday") and (1, "Tuesday").
-  static std::map<std::string,
-                  std::vector<std::tuple<UVCP_CONSTANT, std::string>>>
+  static std::unordered_map<std::string,
+                            std::vector<std::tuple<UVCP_CONSTANT, std::string>>>
       enum_values_dict;
 
   // Given a void pointer and type of the enum, extract out the enum

--- a/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.cc
+++ b/src/google_cloud_debugger/google_cloud_debugger_lib/dbg_stack_frame.cc
@@ -15,7 +15,6 @@
 #include "dbg_stack_frame.h"
 
 #include <iostream>
-#include <map>
 #include <queue>
 #include <vector>
 


### PR DESCRIPTION
Since we don't need a sorted dictionary, unordered_map would be a lot faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-dotnet-debugger/355)
<!-- Reviewable:end -->
