### PR TITLE
Hard code the path the the bash we want to use

### DIFF
--- a/.kokoro/run_integration_tests.bat
+++ b/.kokoro/run_integration_tests.bat
@@ -11,4 +11,4 @@ git submodule update
 call .\build-deps.cmd
 call .\build.cmd
 
-bash run_integration_tests.sh
+"C:\Program Files\Git\bin\bash.exe" run_integration_tests.sh

--- a/.kokoro/run_integration_tests.bat
+++ b/.kokoro/run_integration_tests.bat
@@ -1,4 +1,4 @@
-:: See documentation in type-shell-output.bat
+:: Build the repo's dependencies, the repo and run its integration tests.
 
 set ROOT_DIR=%~dp0..
 cd %ROOT_DIR%

--- a/.kokoro/run_integration_tests.bat
+++ b/.kokoro/run_integration_tests.bat
@@ -1,13 +1,13 @@
 :: See documentation in type-shell-output.bat
 
-cd %~dp0
-cd ..
+set ROOT_DIR=%~dp0..
+cd %ROOT_DIR%
 
 set GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR\73609_cloud-sharp-jenkins-compute-service-account"
 
 git submodule init
 git submodule update
 
-.\build-deps.cmd & ^
-.\build.cmd & ^
-"C:\Program Files\Git\bin\bash.exe" run_integration_tests.sh
+%ROOT_DIR%\build-deps.cmd & ^
+%ROOT_DIR%\build.cmd & ^
+"C:\Program Files\Git\bin\bash.exe" %ROOT_DIR%\run_integration_tests.sh

--- a/.kokoro/run_integration_tests.bat
+++ b/.kokoro/run_integration_tests.bat
@@ -8,7 +8,7 @@ set GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR\73609_cloud-sharp-jenki
 git submodule init
 git submodule update
 
-call .\build-deps.cmd
-call .\build.cmd
+call /k .\build-deps.cmd
+call /k .\build.cmd
 
 "C:\Program Files\Git\bin\bash.exe" run_integration_tests.sh

--- a/.kokoro/run_integration_tests.bat
+++ b/.kokoro/run_integration_tests.bat
@@ -8,6 +8,4 @@ set GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR\73609_cloud-sharp-jenki
 git submodule init
 git submodule update
 
-%ROOT_DIR%\build-deps.cmd & ^
-%ROOT_DIR%\build.cmd & ^
-"C:\Program Files\Git\bin\bash.exe" %ROOT_DIR%\run_integration_tests.sh
+%ROOT_DIR%\build-deps.cmd && %ROOT_DIR%\build.cmd && "C:\Program Files\Git\bin\bash.exe" %ROOT_DIR%\run_integration_tests.sh

--- a/.kokoro/run_integration_tests.bat
+++ b/.kokoro/run_integration_tests.bat
@@ -8,7 +8,6 @@ set GOOGLE_APPLICATION_CREDENTIALS="$KOKORO_KEYSTORE_DIR\73609_cloud-sharp-jenki
 git submodule init
 git submodule update
 
-call /k .\build-deps.cmd
-call /k .\build.cmd
-
+.\build-deps.cmd & ^
+.\build.cmd & ^
 "C:\Program Files\Git\bin\bash.exe" run_integration_tests.sh

--- a/.kokoro/run_unit_tests.bat
+++ b/.kokoro/run_unit_tests.bat
@@ -6,7 +6,6 @@ cd ..
 git submodule init
 git submodule update
 
-call /k .\build-deps.cmd
-call /k .\build.cmd
-
+.\build-deps.cmd & ^
+.\build.cmd & ^
 "C:\Program Files\Git\bin\bash.exe" run_unit_tests.sh

--- a/.kokoro/run_unit_tests.bat
+++ b/.kokoro/run_unit_tests.bat
@@ -1,4 +1,4 @@
-:: See documentation in type-shell-output.bat
+:: Build the repo's dependencies, the repo and run its unit tests.
 
 set ROOT_DIR=%~dp0..
 cd %ROOT_DIR%

--- a/.kokoro/run_unit_tests.bat
+++ b/.kokoro/run_unit_tests.bat
@@ -6,7 +6,7 @@ cd ..
 git submodule init
 git submodule update
 
-call .\build-deps.cmd
-call .\build.cmd
+call /k .\build-deps.cmd
+call /k .\build.cmd
 
 "C:\Program Files\Git\bin\bash.exe" run_unit_tests.sh

--- a/.kokoro/run_unit_tests.bat
+++ b/.kokoro/run_unit_tests.bat
@@ -9,4 +9,4 @@ git submodule update
 call .\build-deps.cmd
 call .\build.cmd
 
-bash run_unit_tests.sh
+"C:\Program Files\Git\bin\bash.exe" run_unit_tests.sh

--- a/.kokoro/run_unit_tests.bat
+++ b/.kokoro/run_unit_tests.bat
@@ -6,6 +6,4 @@ cd %ROOT_DIR%
 git submodule init
 git submodule update
 
-%ROOT_DIR%\build-deps.cmd & ^
-%ROOT_DIR%\build.cmd & ^
-"C:\Program Files\Git\bin\bash.exe" %ROOT_DIR%\run_unit_tests.sh
+%ROOT_DIR%\build-deps.cmd && %ROOT_DIR%\build.cmd && "C:\Program Files\Git\bin\bash.exe" %ROOT_DIR%\run_unit_tests.sh

--- a/.kokoro/run_unit_tests.bat
+++ b/.kokoro/run_unit_tests.bat
@@ -1,11 +1,11 @@
 :: See documentation in type-shell-output.bat
 
-cd %~dp0
-cd ..
+set ROOT_DIR=%~dp0..
+cd %ROOT_DIR%
 
 git submodule init
 git submodule update
 
-.\build-deps.cmd & ^
-.\build.cmd & ^
-"C:\Program Files\Git\bin\bash.exe" run_unit_tests.sh
+%ROOT_DIR%\build-deps.cmd & ^
+%ROOT_DIR%\build.cmd & ^
+"C:\Program Files\Git\bin\bash.exe" %ROOT_DIR%\run_unit_tests.sh


### PR DESCRIPTION
The jobs seem to do some set up starting with cygwin that ignore the PATH.

This also chains the commands together as the build-deps script seems to exit the whole script at times.